### PR TITLE
[Small] [Bug Fix] HotFix

### DIFF
--- a/Assets/StreamingAssets/CSharp/SettingsMenuFunctions.cs
+++ b/Assets/StreamingAssets/CSharp/SettingsMenuFunctions.cs
@@ -105,11 +105,6 @@ public static class SettingsMenuFunctions
         return new FullScreenToggle();
     }
 
-    public static DeveloperModeToggle GetDeveloperModeToggle()
-    {
-        return new DeveloperModeToggle();
-    }
-
     public static SoftParticlesToggle GetSoftParticlesToggle()
     {
         return new SoftParticlesToggle();


### PR DESCRIPTION
With moving projects sometimes errors pop up and this one seems to be with the LUA thing, I must have moved over the LUA to handle the dev mode without removing it in C# then removed just the class but not the function call.  This removes that function call.  Every works after this.