### PR TITLE
[Performance Patch] Fixing GC problems

### DIFF
--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -547,6 +547,8 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
         prevUpdatePowerOn = true;
         Jobs.ResumeAll();
 
+        UnityEngine.Profiling.Profiler.BeginSample("Furniture");
+
         if (EventActions != null)
         {
             EventActions.Trigger("OnUpdate", this, deltaTime);
@@ -561,6 +563,8 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
         {
             Animation.Update(deltaTime);
         }
+
+        UnityEngine.Profiling.Profiler.EndSample();
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -547,8 +547,6 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
         prevUpdatePowerOn = true;
         Jobs.ResumeAll();
 
-        UnityEngine.Profiling.Profiler.BeginSample("Furniture");
-
         if (EventActions != null)
         {
             EventActions.Trigger("OnUpdate", this, deltaTime);
@@ -563,8 +561,6 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
         {
             Animation.Update(deltaTime);
         }
-
-        UnityEngine.Profiling.Profiler.EndSample();
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/DialogBoxInformation/DialogButton.cs
+++ b/Assets/Scripts/Models/DialogBoxInformation/DialogButton.cs
@@ -12,7 +12,7 @@ public class DialogButton : DialogControl
     public string buttonName;
 
     public void OnClicked()
-    { 
+    {
         // These names should actually be something like "button_my" in order to be localized.
         // However, just to make sure, we replace this to avoid any problems.
         buttonName = buttonName.Replace(" ", "_");
@@ -23,7 +23,7 @@ public class DialogButton : DialogControl
         if (dialogEvents.HasEvent("On" + buttonName + "Clicked") == true)
         {
             UnityDebugger.Debugger.Log("ModDialogBox", "Found On" + buttonName + "Clicked event");
-            dialogEvents.Trigger<ModDialogBox>("On" + buttonName + "Clicked", transform.GetComponentInParent<ModDialogBox>());
+            dialogEvents.Trigger("On" + buttonName + "Clicked", transform.GetComponentInParent<ModDialogBox>());
         }
     }
 }

--- a/Assets/Scripts/Models/Events/EventAction.cs
+++ b/Assets/Scripts/Models/Events/EventAction.cs
@@ -95,18 +95,19 @@ public class EventActions
 
     /// <summary>
     /// Fire the event named actionName, resulting in all lua functions being called.
+    /// This one reduces GC bloat.
     /// </summary>
     /// <param name="actionName">Name of the action being triggered.</param>
     /// <param name="target">Object, passed to LUA function as 1-argument.</param>
-    /// <param name="deltaTime">Time since last Trigger of this event.</param>
-    public void Trigger<T>(string actionName, T target, params object[] parameters)
+    /// <param name="parameters">Parameters in question.  First one must be target instance. </param>
+    public void Trigger(string actionName, params object[] parameters)
     {
         if (!actionsList.ContainsKey(actionName) || actionsList[actionName] == null)
         {
         }
         else
         {
-            FunctionsManager.Get(target.GetType().Name).CallWithInstance(actionsList[actionName], target, parameters);
+            FunctionsManager.Get(parameters[0].GetType().Name).Call(actionsList[actionName], parameters);
         }
     }
 

--- a/Assets/Scripts/Models/Functions/CSharpFunctions.cs
+++ b/Assets/Scripts/Models/Functions/CSharpFunctions.cs
@@ -134,30 +134,6 @@ public class CSharpFunctions : IFunctions
         return (T)methods[functionName].Invoke(null, args);
     }
 
-    public void CallWithInstance(string[] functionNames, object instance, params object[] parameters)
-    {
-        foreach (string fn in functionNames)
-        {
-            if (fn == null)
-            {
-                UnityDebugger.Debugger.LogError("CSharp", "'" + fn + "' is not a CSharp function.");
-                return;
-            }
-
-            DynValue result;
-            object[] instanceAndParams = new object[parameters.Length + 1];
-            instanceAndParams[0] = instance;
-            parameters.CopyTo(instanceAndParams, 1);
-
-            result = Call(fn, instanceAndParams);
-
-            if (result != null && result.Type == DataType.String)
-            {
-                UnityDebugger.Debugger.LogError("CSharp", result.String);
-            }
-        }
-    }
-
     public void RegisterType(Type type)
     {
         // nothing to do for C#

--- a/Assets/Scripts/Models/Functions/Functions.cs
+++ b/Assets/Scripts/Models/Functions/Functions.cs
@@ -87,6 +87,23 @@ public class Functions
         }
     }
 
+    /// <summary>
+    /// The Common Call Function expanded for multiple functions.
+    /// </summary>
+    public void Call(List<string> functionNames, params object[] args)
+    {
+        for (int i = 0; i < functionNames.Count; i++)
+        {
+            if (functionNames[i] == null)
+            {
+                UnityDebugger.Debugger.LogError(ModFunctionsLogChannel, "'" + functionNames[i] + "'  is not a LUA nor CSharp function!");
+                continue;
+            }
+
+            Call(functionNames[i], false, args);
+        }
+    }
+
     public void CallWithInstance(List<string> functionNames, object instance, params object[] parameters)
     {
         DynValue result;
@@ -135,7 +152,6 @@ public class Functions
             {
                 throw new Exception("'" + functionName + "' is not a LUA nor is it a CSharp function!");
             }
-
             return null;
         }
     }

--- a/Assets/Scripts/Models/Functions/Functions.cs
+++ b/Assets/Scripts/Models/Functions/Functions.cs
@@ -152,6 +152,7 @@ public class Functions
             {
                 throw new Exception("'" + functionName + "' is not a LUA nor is it a CSharp function!");
             }
+
             return null;
         }
     }

--- a/Assets/Scripts/Models/Functions/LuaFunctions.cs
+++ b/Assets/Scripts/Models/Functions/LuaFunctions.cs
@@ -8,9 +8,9 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using MoonSharp.Interpreter;
 using ProjectPorcupine.PowerNetwork;
-using System.Collections.Generic;
 
 public class LuaFunctions : IFunctions
 {

--- a/Assets/Scripts/Models/Functions/LuaFunctions.cs
+++ b/Assets/Scripts/Models/Functions/LuaFunctions.cs
@@ -10,6 +10,7 @@
 using System;
 using MoonSharp.Interpreter;
 using ProjectPorcupine.PowerNetwork;
+using System.Collections.Generic;
 
 public class LuaFunctions : IFunctions
 {
@@ -61,7 +62,7 @@ public class LuaFunctions : IFunctions
         this.scriptName = scriptName;
         try
         {
-            script.DoString(text);
+            script.DoString(text, script.Globals);
         }
         catch (SyntaxErrorException e)
         {
@@ -87,43 +88,6 @@ public class LuaFunctions : IFunctions
         return Call(functionName, args).ToObject<T>();
     }
 
-    /// <summary>
-    /// Calls the specified lua functions with the specified instance.
-    /// </summary>
-    /// <param name="functionNames">Function names.</param>
-    /// <param name="instance">An instance of the actions type.</param>
-    /// <param name="deltaTime">Delta time.</param>
-    public void CallWithInstance(string[] functionNames, object instance, params object[] parameters)
-    {
-        if (instance == null)
-        {
-            // These errors are about the lua code so putting them in the Lua channel.
-            UnityDebugger.Debugger.LogError("Lua", "Instance is null, cannot call LUA function (something is fishy).");
-        }
-
-        foreach (string fn in functionNames)
-        {
-            if (fn == null)
-            {
-                UnityDebugger.Debugger.LogError("Lua", "'" + fn + "' is not a LUA function.");
-                return;
-            }
-
-            object[] instanceAndParams = new object[parameters.Length + 1];
-            instanceAndParams[0] = instance;
-            parameters.CopyTo(instanceAndParams, 1);
-
-            try
-            {
-                Call(fn, instanceAndParams);
-            }
-            catch (ScriptRuntimeException e)
-            {
-                UnityDebugger.Debugger.LogError("Lua", "[" + scriptName + "] LUA RunTime error: " + e.DecoratedMessage);
-            }
-        }
-    }
-
     public void RegisterType(Type type)
     {
         RegisterGlobal(type);
@@ -136,15 +100,18 @@ public class LuaFunctions : IFunctions
     /// <param name="args">Arguments.</param>
     private DynValue Call(string functionName, bool throwError, params object[] args)
     {
-        object func = script.Globals[functionName];
-
         try
         {
-            return script.Call(func, args);
+            return ((Closure)script.Globals[functionName]).Call(args);
         }
         catch (ScriptRuntimeException e)
         {
             UnityDebugger.Debugger.LogError("Lua", "[" + scriptName + "] LUA RunTime error: " + e.DecoratedMessage);
+            return null;
+        }
+        catch (Exception e)
+        {
+            UnityDebugger.Debugger.LogError("Lua", "[" + scriptName + "] Something else went wrong: " + e.Message);
             return null;
         }
     }


### PR DESCRIPTION
From me and koose having a look at the code we have both decided that a major problem is Moonsharp allocating tons of GC, at one point we may even want to hold onto the memory and do our own allocation if it really gets bad.  There are alternative ways like hardwiring which I'm also looking into.  

This aims to alleviate some of those problems.  It does a ton of work for furniture, and basically everything runs in the GameController update (about 70% of things) runs on less than 2kb/cycle (excluding Moonsharp).  However Moonsharp is using about 78kb/cycle (both from my profiling and their own profiler logs).  This is on a low, on highs it can go up to 120 with the whole thing running on less than 5kb/cycle for those high moments with the rest being Moonsharp.  

This patch helps a little by reducing that around by 2kb/cycle so on lows Moonsharp runs on about 76kb/cycle instead of 78kb.  It also reduces the general use of memory and makes the highs less high, removes the copying of arrays too.

This won't fix any temperature stuff since that's in a different PR.  There is probably still much more that can be done.