### PR TITLE
Add Xml Header on Ships and fix incorrect tile types

### DIFF
--- a/Assets/StreamingAssets/Data/Ships.xml
+++ b/Assets/StreamingAssets/Data/Ships.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Ships>
     <Ship type="essentia" width="3" height="5">
         <BerthPoint x="1" y="5" direction="NORTH" />
@@ -16,21 +17,21 @@
         </Storages>
         
         <Tiles>
-            <Tile x="0" y="0" type="Floor" />
-            <Tile x="1" y="0" type="Floor" />
-            <Tile x="2" y="0" type="Floor" />
-            <Tile x="0" y="1" type="Floor" />
-            <Tile x="1" y="1" type="Floor" />
-            <Tile x="2" y="1" type="Floor" />
-            <Tile x="0" y="2" type="Floor" />
-            <Tile x="1" y="2" type="Floor" />
-            <Tile x="2" y="2" type="Floor" />
-            <Tile x="0" y="3" type="Floor" />
-            <Tile x="1" y="3" type="Floor" />
-            <Tile x="2" y="3" type="Floor" />
-            <Tile x="0" y="4" type="Floor" />
-            <Tile x="1" y="4" type="Floor" />
-            <Tile x="2" y="4" type="Floor" />
+            <Tile x="0" y="0" type="floor" />
+            <Tile x="1" y="0" type="floor" />
+            <Tile x="2" y="0" type="floor" />
+            <Tile x="0" y="1" type="floor" />
+            <Tile x="1" y="1" type="floor" />
+            <Tile x="2" y="1" type="floor" />
+            <Tile x="0" y="2" type="floor" />
+            <Tile x="1" y="2" type="floor" />
+            <Tile x="2" y="2" type="floor" />
+            <Tile x="0" y="3" type="floor" />
+            <Tile x="1" y="3" type="floor" />
+            <Tile x="2" y="3" type="floor" />
+            <Tile x="0" y="4" type="floor" />
+            <Tile x="1" y="4" type="floor" />
+            <Tile x="2" y="4" type="floor" />
         </Tiles>
         
         <Furnitures>


### PR DESCRIPTION
ships.xml was missing the xml header, and had the old tile types (different capitalization)