### PR TITLE
Fix TraderPrototype Animation Creation

### DIFF
--- a/Assets/Scripts/Models/Trade/TraderPrototype.cs
+++ b/Assets/Scripts/Models/Trade/TraderPrototype.cs
@@ -205,10 +205,10 @@ public class TraderPrototype : IPrototypable
                 switch (state)
                 {
                     case "idle":
-                        AnimationIdle = new SpritenameAnimation(state, framesSpriteNames.ToArray(), fps, looping, valueBased);
+                        AnimationIdle = new SpritenameAnimation(state, framesSpriteNames.ToArray(), fps, looping, false, valueBased);
                         break;
                     case "flying":
-                        AnimationFlying = new SpritenameAnimation(state, framesSpriteNames.ToArray(), fps, looping, valueBased);
+                        AnimationFlying = new SpritenameAnimation(state, framesSpriteNames.ToArray(), fps, looping, false, valueBased);
                         break;
                 }
             }


### PR DESCRIPTION
TraderPrototype incorrectly passes valueBased parameter in the position of flipX parameter. This simply inserts `false` (the default value of flipX) into that position, pushing valueBased into the correct position.