### PR TITLE
Fix TraderPrototype Animation Creation ( #66 )

### DIFF
--- a/Assets/Scripts/Models/Trade/TraderPrototype.cs
+++ b/Assets/Scripts/Models/Trade/TraderPrototype.cs
@@ -205,10 +205,10 @@ public class TraderPrototype : IPrototypable
                 switch (state)
                 {
                     case "idle":
-                        AnimationIdle = new SpritenameAnimation(state, framesSpriteNames.ToArray(), fps, looping, valueBased);
+                        AnimationIdle = new SpritenameAnimation(state, framesSpriteNames.ToArray(), fps, looping, false, valueBased);
                         break;
                     case "flying":
-                        AnimationFlying = new SpritenameAnimation(state, framesSpriteNames.ToArray(), fps, looping, valueBased);
+                        AnimationFlying = new SpritenameAnimation(state, framesSpriteNames.ToArray(), fps, looping, false, valueBased);
                         break;
                 }
             }


### PR DESCRIPTION
Fixes #66 

Fixes bug where not set in xml causing fps of 0 to be passed (in TraderPrototype and Furniture)

Fixes bug where fps is being passed as delay (in TraderPrototype)

Still leaves the repetition of code in the various ways Animation is handled, and each thing that uses animation handling their own xml processing (giving the potential for future inconsistencies and bugs due to multiple classes reimplementing the same behavior), but this is a more significant issue, so I will raise it in a separate issue, rather than letting these simpler bugfixes wait while a more full solution is approached.