### PR TITLE
Fix SettingsOption creating phantom Options

### DIFF
--- a/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsOption.cs
+++ b/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsOption.cs
@@ -33,10 +33,12 @@ public class SettingsOption
     /// </summary>
     public SettingsOption(XmlReader reader)
     {
-        name = reader.GetAttribute("Name");
-        key = reader.GetAttribute("Key");
-        defaultValue = reader.GetAttribute("DefaultValue");
-        className = reader.GetAttribute("ClassName");
-        this.options = (reader != null && reader.ReadToDescendant("Params")) ? Parameter.ReadXml(reader) : new Parameter();
+            XmlReader subReader = reader.ReadSubtree();
+            name = reader.GetAttribute("Name");
+            key = reader.GetAttribute("Key");
+            defaultValue = reader.GetAttribute("DefaultValue");
+            className = reader.GetAttribute("ClassName");
+            this.options = (reader != null && subReader.ReadToDescendant("Params")) ? Parameter.ReadXml(reader) : new Parameter();
+            subReader.Close();
     }
 }


### PR DESCRIPTION
SettingsOption in its current form doesn't read in the closing tag, leaving a closing tag for the category to read, which the xmlReader doesn't recognize as a closing tag. Slightly changing SettingsOption to use ReadSubTree, lets it properly close the tag, rather the Option is a self closing tag or a normal tag with a separate closing tag.