### PR TITLE
Small tweaks to prebuilt binaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ For further information, such as Roadmaps, explanations of systems and features,
 Make sure that you are using Unity 5.5.3 [Windows](https://unity3d.com/get-unity/download?thank-you=update&download_nid=46772&os=Win) | [Mac](https://unity3d.com/get-unity/download?thank-you=update&download_nid=46772&os=Mac)
 
 ## Weeklies
+
+You can download and play already built 'weekly' versions for Windows, Mac, and Linux [here](https://bintray.com/orderoftheporcupine/ProjectPorcupine/Prebuilt-Binaries).
+
+However, are merely 'snapshots', a preview of the current development build, and are not representative of any type of release. They may contain errors, bugs, partially completed features, and other potential issues.  If you open a bug report please include what week you are using (either the week number or the date is fine) as this will help us find the bug easier and determine if your error has already been fixed.
+
+## Weeklies
 For prebuilt binaries of weekly progress go to https://bintray.com/orderoftheporcupine/ProjectPorcupine/Prebuilt-Binaries (Windows, Linux, and MacOSX available.
 
 Note: These are weekly automated snapshots, so may contain assorted errors, half-finished features, and other potential issues. They are in no way guaranteed to be reliable, and in fact could almost guaranteed to be quite unreliable. Use at your own risk.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ For further information, such as Roadmaps, explanations of systems and features,
 
 Make sure that you are using Unity 5.5.3 [Windows](https://unity3d.com/get-unity/download?thank-you=update&download_nid=46772&os=Win) | [Mac](https://unity3d.com/get-unity/download?thank-you=update&download_nid=46772&os=Mac)
 
+## Weeklies
+For prebuilt binaries of weekly progress go to https://bintray.com/orderoftheporcupine/ProjectPorcupine/Prebuilt-Binaries (Windows, Linux, and MacOSX available.
+
+Note: These are weekly automated snapshots, so may contain assorted errors, half-finished features, and other potential issues. They are in no way guaranteed to be reliable, and in fact could almost guaranteed to be quite unreliable. Use at your own risk.
+
 ## Community
 
 * [Offical Discord Channel ](https://discord.gg/68hkpSA)<discord.projectporcupine.com>

--- a/Scripts/bintray.json.erb
+++ b/Scripts/bintray.json.erb
@@ -1,7 +1,7 @@
 <% version = Time.now.strftime("%Y.%V") # (year).(week), e.g. 2017.15 %>
 {
     "package": {
-        "name": "Prebuild-Binarys",
+        "name": "Prebuilt-Binaries",
         "repo": "ProjectPorcupine",
         "subject": "orderoftheporcupine",
         "desc": "Weekly dev-build #<%= version %>"

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -37,9 +37,11 @@ echo 'Logs from build'
 cat $(pwd)/unity.log
 
 echo 'Attempting to zip builds'
-zip -q -r $(pwd)/Build/Linux.zip $(pwd)/Build/linux/
-zip -q -r $(pwd)/Build/MacOSX.zip $(pwd)/Build/osx/
-zip -q -r $(pwd)/Build/Windows.zip $(pwd)/Build/windows/
+cd $(pwd)/Build/
+zip -q -r Linux.zip linux/
+zip -q -r MacOSX.zip osx/
+zip -q -r Windows.zip windows/
+cd -
 
 # create the config file for Bintray through ERB (an ruby cli-tool)
 erb ./Scripts/bintray.json.erb > ./Scripts/bintray.json


### PR DESCRIPTION
Zip paths for the prebuilt binaries are a little too deep (starting from travis' current working directory, this instead changes the directory to a closer directory before zipping to create shallower directory paths.

This also changes the name to Prebuilt Binaries (with the accompanying changes to bintray), and adds the link to them to the Readme (language may need further review, but the general intent should remain the same).

I will delay merging this for a short time (a day or two at most) to allow time for people to review the wording around the added Weeklies section in the Readme, barring any extended discussion/debate on it.