### PR TITLE
Remove Need Name, switch to Type

### DIFF
--- a/Assets/Scripts/Models/Character/Character.cs
+++ b/Assets/Scripts/Models/Character/Character.cs
@@ -380,7 +380,7 @@ public class Character : ISelectable, IContextActionProvider, IUpdatable
         JObject needsJSon = new JObject();
         foreach (Need need in Needs)
         {
-            needsJSon.Add(need.Name, need.Amount);
+            needsJSon.Add(need.Type, need.Amount);
         }
 
         characterJson.Add("Needs", needsJSon);

--- a/Assets/Scripts/Models/Job/Need.cs
+++ b/Assets/Scripts/Models/Job/Need.cs
@@ -29,7 +29,6 @@ public class Need : IPrototypable
         Amount = 0;
         Type = other.Type;
         LocalizationID = other.LocalizationID;
-        Name = other.Name;
         GrowthRate = other.GrowthRate;
         highToLow = other.highToLow;
         RestoreNeedFurn = other.RestoreNeedFurn;
@@ -48,8 +47,6 @@ public class Need : IPrototypable
     public string Type { get; private set; }
 
     public string LocalizationID { get; private set; }
-
-    public string Name { get; private set; }
 
     public float Amount
     {
@@ -153,10 +150,6 @@ public class Need : IPrototypable
         {
             switch (reader.Name)
             {
-                case "Name":
-                    reader.Read();
-                    Name = reader.ReadContentAsString();
-                    break;
                 case "RestoreNeedFurnitureType":
                     reader.Read();
                     RestoreNeedFurn = PrototypeManager.Furniture.Get(reader.ReadContentAsString());

--- a/Assets/StreamingAssets/Data/Need.xml
+++ b/Assets/StreamingAssets/Data/Need.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Needs>
     <Need type="oxygen">
-        <Name>Oxygen</Name>
         <GrowthRate>0.3</GrowthRate>
         <RestoreNeedFurnitureType>oxygen_generator</RestoreNeedFurnitureType>
         <RestoreNeedTime>10</RestoreNeedTime>
@@ -14,7 +13,6 @@
     </Need>
 
     <Need type="sleep">
-        <Name>Sleep</Name>
         <RestoreNeedFurnitureType>simple_bed</RestoreNeedFurnitureType>
         <!-- A GrowthRate of .15 approximates a "day (16 hours of awake time + 8 hours of sleep time)
              that is approximately 1000 seconds long. RestoreNeedTime has not yet been adjusted to the


### PR DESCRIPTION
Removes Name from Needs, as that is a relic of prelocalization, and only serves to cause confusion now. 