### PR TITLE
Remove Min/Max from overlay

### DIFF
--- a/Assets/Scripts/UI/Overlay/OverlayDescriptor.cs
+++ b/Assets/Scripts/UI/Overlay/OverlayDescriptor.cs
@@ -21,8 +21,6 @@ public class OverlayDescriptor : IPrototypable
     public OverlayDescriptor()
     {
         ColorMap = ColorMapOption.Jet;
-        Min = 0;
-        Max = 255;
     }
 
     /// <summary>
@@ -60,32 +58,12 @@ public class OverlayDescriptor : IPrototypable
     public string LuaFunctionName { get; private set; }
 
     /// <summary>
-    /// Gets the min bound for clipping coloring.
-    /// </summary>
-    public int Min { get; private set; }
-
-    /// <summary>
-    /// Gets the max bound for clipping coloring.
-    /// </summary>
-    public int Max { get; private set; }
-
-    /// <summary>
     /// Creates an OverlayDescriptor form a xml subtree with node \<Overlay></Overlay>\.
     /// </summary>
     /// <param name="xmlReader">The subtree pointing to Overlay.</param>
     public void ReadXmlPrototype(XmlReader xmlReader)
     {
         Type = xmlReader.GetAttribute("type");
-
-        if (xmlReader.GetAttribute("min") != null)
-        {
-            Min = XmlConvert.ToInt32(xmlReader.GetAttribute("min"));
-        }
-
-        if (xmlReader.GetAttribute("max") != null)
-        {
-            Max = XmlConvert.ToInt32(xmlReader.GetAttribute("max"));
-        }
 
         if (xmlReader.GetAttribute("colorMap") != null)
         {

--- a/Assets/StreamingAssets/Data/Overlay.xml
+++ b/Assets/StreamingAssets/Data/Overlay.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Overlays>
     <!-- List of overlay prototypes -->
-    <!-- id attribute is mandatory and must be unique -->
-    <!-- min: minimal value attained by funtion (data will be clipped) -->
-    <!-- max: maximal value attained by funtion (data will be clipped) -->
+    <!-- type attribute is mandatory and must be unique -->
     <!-- colorMap: selection of coloring scheme for overlay (defaults to "jet") -->
     <!-- content: lua function name, called on each tile, must return int -->
-    <Overlay type="oxygen" min="0" max="1" colorMap="Jet">oxygenValueAt</Overlay>
-    <Overlay type="room" min="0" max="1" colorMap="Random">roomNumberValueAt</Overlay>
-    <Overlay type="power" min="0" max="1" colorMap="Jet">powerValueAt</Overlay>
-    <Overlay type="temperature" min="0" max="1" colorMap="Jet">temperatureValueAt</Overlay>
-    <Overlay type="power_network" min="0" max="1" colorMap="Palette">PowerGridAt</Overlay>
-    <Overlay type="fluid_network" min="0" max="1" colorMap="Palette">FluidGridAt</Overlay>
-    <Overlay type="debug_thermal_diffusivity" min="0" max="1" colorMap="Jet">thermalDiffusivityValueAt</Overlay>
-    <Overlay type="debug_heat_generation" min="0" max="1" colorMap="Jet">heatGenerationValueAt</Overlay>
+    <Overlay type="oxygen" colorMap="Jet">oxygenValueAt</Overlay>
+    <Overlay type="room" colorMap="Random">roomNumberValueAt</Overlay>
+    <Overlay type="power" colorMap="Jet">powerValueAt</Overlay>
+    <Overlay type="temperature" colorMap="Jet">temperatureValueAt</Overlay>
+    <Overlay type="power_network" colorMap="Palette">PowerGridAt</Overlay>
+    <Overlay type="fluid_network" colorMap="Palette">FluidGridAt</Overlay>
+    <Overlay type="debug_thermal_diffusivity" colorMap="Jet">thermalDiffusivityValueAt</Overlay>
+    <Overlay type="debug_heat_generation" colorMap="Jet">heatGenerationValueAt</Overlay>
 </Overlays>


### PR DESCRIPTION
Min and Max are unused by overlays, and seemed to serve little point.