### PR TITLE
Add BUILD_VERSION to files and set it globally in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ before_install:
  - chmod +x ./Scripts/check-style.sh
  - chmod +x ./Scripts/travis.sh
 env:
-  - JOB=unit-test
-  - JOB=stylecop
+  global:
+    - BUILD_VERSION=$( date +%Y.%V )
+  matrix:
+    - JOB=unit-test
+    - JOB=stylecop
 script:
 - ./Scripts/travis.sh
 notifications:

--- a/Scripts/bintray.json.erb
+++ b/Scripts/bintray.json.erb
@@ -1,14 +1,13 @@
-<% version = Time.now.strftime("%Y.%V") # (year).(week), e.g. 2017.15 %>
 {
     "package": {
         "name": "Prebuilt-Binaries",
         "repo": "ProjectPorcupine",
         "subject": "orderoftheporcupine",
-        "desc": "Weekly dev-build #<%= version %>"
+        "desc": "Weekly dev-build #<%= ENV['BUILD_VERSION'] %>"
     },
 
     "version": {
-        "name": "<%= version %>",
+        "name": "<%= ENV['BUILD_VERSION'] %>",
         "released": "<%= Time.now.strftime("%Y-%m-%d") %>",
         "attributes": [],
         "gpgSign": false

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -38,9 +38,9 @@ cat $(pwd)/unity.log
 
 echo 'Attempting to zip builds'
 cd $(pwd)/Build/
-zip -q -r Linux.zip linux/
-zip -q -r MacOSX.zip osx/
-zip -q -r Windows.zip windows/
+zip -q -r Linux-$BUILD_VERSION.zip linux/
+zip -q -r MacOSX-$BUILD_VERSION.zip osx/
+zip -q -r Windows-$BUILD_VERSION.zip windows/
 cd -
 
 # create the config file for Bintray through ERB (an ruby cli-tool)


### PR DESCRIPTION
Fixes #88 (and probably #87 as not really the "latest" Windows Version was used. There is no point in debugging an 4 week old build)

As usual this can't really be tested so please @koosemose  review the code for obvious typos but other than that its merge and hope :cry:

Btw I didn't find any hint that the same names aren't allowed (other than the error message) I thought that the version (tag) is sufficient thats what I wanted. A new version of the same file(name) but I looked thorugh some other repos @ bintray and they all include the Version number in the filename.