### PR TITLE
Fix InventoryUI Prefab

### DIFF
--- a/Assets/Scripts/Controllers/WorldController.cs
+++ b/Assets/Scripts/Controllers/WorldController.cs
@@ -22,6 +22,9 @@ public class WorldController : MonoBehaviour
     [SerializeField]
     private GameObject circleCursorPrefab;
 
+    [SerializeField]
+    private GameObject inventoryUI;
+
     #region Instances
     public static WorldController Instance { get; protected set; }
 
@@ -58,8 +61,6 @@ public class WorldController : MonoBehaviour
     public ModsManager ModsManager { get; private set; }
 
     public DialogBoxManager DialogBoxManager { get; private set; }
-
-    public GameObject InventoryUI { get; private set; }
 
     // The world and tile data.
     public World World { get; protected set; }
@@ -113,7 +114,7 @@ public class WorldController : MonoBehaviour
         FurnitureSpriteController = new FurnitureSpriteController(World);
         UtilitySpriteController = new UtilitySpriteController(World);
         JobSpriteController = new JobSpriteController(World, FurnitureSpriteController, UtilitySpriteController);
-        InventorySpriteController = new InventorySpriteController(World, InventoryUI);
+        InventorySpriteController = new InventorySpriteController(World, inventoryUI);
         ShipSpriteController = new ShipSpriteController(World);
 
         BuildModeController = new BuildModeController();

--- a/Assets/_Scenes_/_World.unity
+++ b/Assets/_Scenes_/_World.unity
@@ -184,6 +184,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   circleCursorPrefab: {fileID: 110048, guid: 782976062f887844ca858482495fcdbd, type: 2}
+  inventoryUI: {fileID: 191780, guid: d1e1fcd802f51614595cb99879a132a5, type: 2}
 --- !u!4 &179601669
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
InventoryUI was broken by a recent commit (InventoryUI being the UI bit that shows the number of objects in a stack of Inventory).

This simply changes it back to a field and makes it private and tells Unity to serialize it (the only reason it was public previously was to serialize it, and it isn't used anywhere else, just to pass along to InventorySpriteManager).