### PR TITLE
Fix Gas Splitting

### DIFF
--- a/Assets/Scripts/Models/Area/AtmosphereComponent.cs
+++ b/Assets/Scripts/Models/Area/AtmosphereComponent.cs
@@ -235,7 +235,6 @@ public class AtmosphereComponent
             return;
         }
 
-
         amount = Mathf.Min(this.TotalGas, amount);
 
         string[] gasNames = this.GetGasNames();

--- a/Assets/Scripts/Models/Area/AtmosphereComponent.cs
+++ b/Assets/Scripts/Models/Area/AtmosphereComponent.cs
@@ -235,14 +235,24 @@ public class AtmosphereComponent
             return;
         }
 
+
         amount = Mathf.Min(this.TotalGas, amount);
 
         string[] gasNames = this.GetGasNames();
+
+        // HACK: tracking the amount to transfer with an array and a separate loop is likely
+        // innefficient, it may instead be better to adjust amount appropriately by the amount
+        // removed.
+        float[] partialAmounts = new float[gasNames.Length];
         for (int i = 0; i < gasNames.Length; i++)
         {
-            float partialAmount = amount * GetGasFraction(gasNames[i]);
-            this.ChangeGas(gasNames[i], -partialAmount);
-            destination.ChangeGas(gasNames[i], partialAmount);
+            partialAmounts[i] = amount * GetGasFraction(gasNames[i]);
+        }
+
+        for (int i = 0; i < gasNames.Length; i++)
+        {
+            this.ChangeGas(gasNames[i], -partialAmounts[i]);
+            destination.ChangeGas(gasNames[i], partialAmounts[i]);
         }
 
         float thermalDelta = amount * internalTemperature.InKelvin;

--- a/Assets/Scripts/Models/Area/AtmosphereComponent.cs
+++ b/Assets/Scripts/Models/Area/AtmosphereComponent.cs
@@ -242,7 +242,7 @@ public class AtmosphereComponent
 
         // HACK: tracking the amount to transfer with an array and a separate loop is likely
         // innefficient, it may instead be better to adjust amount appropriately by the amount
-        // removed.
+        // removed. In our standard rooms gas ratio should remain 20% O2, 80% N2
         float[] partialAmounts = new float[gasNames.Length];
         for (int i = 0; i < gasNames.Length; i++)
         {


### PR DESCRIPTION
Currently, gas does not move correctly, this shows both when joining rooms (deleting a wall between rooms) or in equalization (such as through doors or a vent). 

The cause is as each gas is moved, it does it based on the total to be moved and the ratio of that gas in the room, after the first gas is moved, the total amount in the room is changed (thus changing the ratio of the second gas in the room) but the total to move isn't changed, so when the second gas is moved, it has a higher than previous ratio of the total amount to move. This *may* also cause additional gas of the second (and further) type to be generated as well, though I haven't thoroughly tested this second issue, as fixing the first should fix the second should it exist.

Presently this is done with a second loop, setting the amount to be moved of each gas *before* actually changing the gasses.

This is a somewhat hackish way to do it, but does work, and I haven't yet had the opportunity to run the math on a *proper* way to do it (It may be as simple as adjusting the total amount to move by the amount moved, but I am not completely certain if that will work quite as intended). The area affected has been marked with a HACK comment to note where it may need updated to a more efficient method that doesn't use an additional array and loop.