### PR TITLE
Remove Expired Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ However, these are merely 'snapshots', a preview of the current development buil
 
 ## Community
 
-* [Offical Discord Channel ](https://discord.gg/68hkpSA)<discord.projectporcupine.com>
+* [Offical Discord Channel ](https://discord.gg/68hkpSA)
 * [Unoffical Subreddit](https://reddit.com/r/ProjectPorcupine)
 
 ## Contact


### PR DESCRIPTION
I Registered the projectporcupine.com domain when there was talk for creating a dev blog, it has since expired so this reference to it should be removed.