### PR TITLE
[Fix] Settings Bugs

### DIFF
--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -69,9 +69,6 @@ public class GameController : MonoBehaviour
     // Only on first time a scene is loaded.
     private void Start()
     {
-        // Load settings.
-        Settings.LoadSettings();
-
         // Add a gameobject that Localization
         this.gameObject.AddComponent<LocalizationLoader>();
     }
@@ -84,14 +81,14 @@ public class GameController : MonoBehaviour
     // Game Controller will persist between scenes. 
     private void EnableDontDestroyOnLoad()
     {
-        if (Instance == null)
+        if (Instance == null || Instance == this)
         {
             Instance = this;
         }
         else
         {
+            UnityDebugger.Debugger.LogError("Two 'MainMenuController' exist, deleting the new version rather than the old.");
             Destroy(this.gameObject);
-            Destroy(this);
         }
 
         DontDestroyOnLoad(this);

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -18,21 +18,30 @@ public class MainMenuController : MonoBehaviour
 
     public DialogBoxManager DialogBoxManager { get; private set; }
 
-    // Use this for initialization.
-    public void OnEnable()
+    public void Awake()
     {
+        if (Instance == null || Instance == this)
+        {
+            Instance = this;
+        }
+        else
+        {
+            UnityDebugger.Debugger.LogError("Two 'MainMenuController' exist, deleting the new version rather than the old.");
+            Destroy(this.gameObject);
+        }
+
         new PrototypeManager();
         new FunctionsManager();
+        new SpriteManager();
+        new AudioManager();
+
+        // Load Mods and Settings on awake rather than on Starts
+        ModsManager = new ModsManager();
+        Settings.LoadSettings();
     }
 
     public void Start()
     {
-        Instance = this;
-
-        new SpriteManager();
-        new AudioManager();
-        ModsManager = new ModsManager();
-
         TimeManager.Instance.IsPaused = true;
 
         // Create a Background.

--- a/Assets/Scripts/Controllers/WorldController.cs
+++ b/Assets/Scripts/Controllers/WorldController.cs
@@ -69,12 +69,14 @@ public class WorldController : MonoBehaviour
 
     public void OnEnable()
     {
-        if (Instance != null)
+        if (Instance == null || Instance == this)
+        {
+            Instance = this;
+        }
+        else
         {
             UnityDebugger.Debugger.LogError("WorldController", "There should never be two world controllers.");
         }
-
-        Instance = this;
 
         new FunctionsManager();
         new PrototypeManager();
@@ -89,6 +91,9 @@ public class WorldController : MonoBehaviour
                 (evt) => UnityDebugger.Debugger.LogFormat("Scheduler", "Event {0} fired", evt.Name)));
 
         ModsManager = new ModsManager();
+
+        // Reload incase any mods have changed settings
+        Settings.LoadSettings();
 
         if (SceneController.LoadWorldFromFileName != null)
         {

--- a/Assets/Scripts/Localization/LocalizationLoader.cs
+++ b/Assets/Scripts/Localization/LocalizationLoader.cs
@@ -35,7 +35,7 @@ namespace ProjectPorcupine.Localization
             }
 
             // Attempt to get setting of currently selected language. (Will default to English).
-            string lang = Settings.GetSettingWithOverwrite("localization", "en_US");
+            string lang = SettingsKeyHolder.SelectedLanguage;
 
             // Setup LocalizationTable with either loaded or defaulted language
             LocalizationTable.currentLanguage = lang;

--- a/Assets/Scripts/Models/Settings/Settings.cs
+++ b/Assets/Scripts/Models/Settings/Settings.cs
@@ -177,11 +177,8 @@ public static class Settings
 
             foreach (string keyName in jsonDictionary.Keys)
             {
-
-
                 settingsDict[keyName] = jsonDictionary[keyName];
             }
-
         }
         else
         {

--- a/Assets/Scripts/Models/Settings/Settings.cs
+++ b/Assets/Scripts/Models/Settings/Settings.cs
@@ -25,11 +25,6 @@ public static class Settings
     private static string userSettingsFilePath = System.IO.Path.Combine(
         Application.persistentDataPath, "Settings.json");
 
-    static Settings()
-    {
-        LoadSettings();
-    }
-
     public static string GetSettingWithOverwrite(string key, string defaultValue)
     {
         if (settingsDict == null)
@@ -158,8 +153,7 @@ public static class Settings
 
         // Load the settings Json file.
         // First try the user's private settings file in userSettingsFilePath.
-        // If that doesn't work fall back to defaultSettingsFilePath.
-        // If that doesn't work fall back to the hard coded FallbackSettingJson above.
+        // If that doesn't work fall back to the settingsTemplate above.
         if (System.IO.File.Exists(userSettingsFilePath) == false)
         {
             UnityDebugger.Debugger.Log("Settings", "User settings file could not be found at '" + userSettingsFilePath);
@@ -183,8 +177,16 @@ public static class Settings
 
             foreach (string keyName in jsonDictionary.Keys)
             {
+
+
                 settingsDict[keyName] = jsonDictionary[keyName];
             }
+
+        }
+        else
+        {
+            UnityDebugger.Debugger.LogError("No User Settings; Saving Defaults to User Data");
+            SaveSettings(); // Save Defaults
         }
     }
 
@@ -196,7 +198,7 @@ public static class Settings
         // It just gets the dictionary values, then the next values, then since its a jagged array it then simplifies it
         SettingsOption[] settingsOptions = PrototypeManager.SettingsCategories.Values
                                                                          .SelectMany(x => x.headings.Values)
-                                                                         .SelectMany(x => x)
+                                                                         .SelectMany(x => x)                 // Collapse
                                                                          .ToArray();
 
         settingsDict = new Dictionary<string, string>();

--- a/Assets/StreamingAssets/MainMenu/Audio.meta
+++ b/Assets/StreamingAssets/MainMenu/Audio.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 151b325d7581dd64e815fab1496f34ee
+folderAsset: yes
+timeCreated: 1508894245
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Settings had a few bugs mainly to do with the order of loading the settings file.  It worked (honestly more like a miracle) that the order was fine in World but somehow the execution order wasn't in _MainMenu.  So this just fixes that, by removing the static load (which in actual fact didn't 'really' work unless the user had all the settings already) and moved a lot of the initialisation code from start to awake in `MainMenuController` for mods just so settings can load properly.  

When I redo GameController in #99 this will be nicer as right now it's a bandaid fix (well more like a bandage fix its more holistic), this won't effect anything but some weird side effects 'could' occur, though I did pretty intensive testing and they didn't.  And when #99 gets merged in eventually this weirdness will go away and things will be initialized where they should in Start.

Furthermore I fixed a few singletons that were not particularly safe (and one that didn't even check for null just assigned), that were in GameController and MainMenuController.  Fixed up a wrong call to Settings too, that could become a bug if the name changes in the future; and I added a nice little thing that just saves the defaults to the user's settings file location IF they don't have a settings file, which basically means that when you initially load the game you'll get a settings file with everything in it rather than having to press save on settings menu (which while arguably isn't a 'bug' it's an odd thing to do).

Anyways I'll merge this in soon-ish if there is no issues.