### PR TITLE
Localization data switch from XML to JSON

### DIFF
--- a/Assets/Scripts/Localization/LocalizationData.cs
+++ b/Assets/Scripts/Localization/LocalizationData.cs
@@ -17,11 +17,11 @@ namespace ProjectPorcupine.Localization
     [JsonObject(MemberSerialization.OptIn)]
     public class LocalizationData
     {
-        [JsonProperty("code")]
-        public readonly string LocalizationCode;
-
         [JsonProperty("rtl")]
-        public bool IsRightToLeft = false;
+        public bool isRightToLeft = false;
+
+        [JsonProperty("code")]
+        private readonly string localizationCode;
 
         // Even for RTL languages, this is kept as defined in xml. The property does the character reversal
         [JsonProperty("name")]
@@ -29,34 +29,34 @@ namespace ProjectPorcupine.Localization
 
         public LocalizationData(string localizationCode, string localName, bool isRightToLeft = false)
         {
-            this.LocalizationCode = localizationCode;
+            this.localizationCode = localizationCode;
             this.localName = localName ?? localizationCode;
-            this.IsRightToLeft = isRightToLeft;
+            this.isRightToLeft = isRightToLeft;
         }
 
         public string LocalName
         {
             get
             {
-                if (IsRightToLeft == false)
+                if (isRightToLeft == false)
                 {
-                    return localName;
+                    return LocalName;
                 }
                 else
                 {
-                    return LocalizationTable.ReverseString(localName);
+                    return LocalizationTable.ReverseString(LocalName);
                 }
             }
 
             set
             {
-                localName = value;
+                LocalName = value;
             }
         }
 
         public override string ToString()
         {
-            return LocalizationCode + "," + IsRightToLeft + "," + localName;
+            return localizationCode + "," + isRightToLeft + "," + LocalName;
         }
     }
 }

--- a/Assets/Scripts/Localization/LocalizationData.cs
+++ b/Assets/Scripts/Localization/LocalizationData.cs
@@ -7,21 +7,24 @@
 // ====================================================
 #endregion
 
-using System.Collections;
-using UnityEngine;
+using Newtonsoft.Json;
 
 namespace ProjectPorcupine.Localization
 {
     /// <summary>
     /// Holds information about a language's configuration data.
     /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
     public class LocalizationData
     {
+        [JsonProperty("code")]
         public readonly string LocalizationCode;
 
-        public bool IsRightToLeft;
+        [JsonProperty("rtl")]
+        public bool IsRightToLeft = false;
 
         // Even for RTL languages, this is kept as defined in xml. The property does the character reversal
+        [JsonProperty("name")]
         private string localName;
 
         public LocalizationData(string localizationCode, string localName, bool isRightToLeft = false)
@@ -49,6 +52,11 @@ namespace ProjectPorcupine.Localization
             {
                 localName = value;
             }
+        }
+
+        public override string ToString()
+        {
+            return LocalizationCode + "," + IsRightToLeft + "," + localName;
         }
     }
 }

--- a/Assets/Scripts/Localization/LocalizationDownloader.cs
+++ b/Assets/Scripts/Localization/LocalizationDownloader.cs
@@ -101,26 +101,36 @@ namespace ProjectPorcupine.Localization
                 UnityDebugger.Debugger.Log("LocalizationDownloader", "There is an update for localization files!");
                 yield return DownloadLocalizationFromWeb(onLocalizationDownloadedCallback);
 
-                // Because config.xml exists in the new downloaded localization, we have to add the version element to it.
-                try
-                {
-                    string configPath = Path.Combine(LocalizationFolderPath, "config.xml");
-                    XmlDocument document = new XmlDocument();
-                    document.Load(configPath);
-                    XmlNode node = document.SelectSingleNode("//config");
+                UpdateConfigFile(latestCommitHash);
+            }
+        }
 
-                    XmlElement versionElement = document.CreateElement("version");
-                    versionElement.SetAttribute("hash", latestCommitHash);
-                    node.InsertBefore(versionElement, document.SelectSingleNode("//languages"));
-                    document.Save(configPath);
-                }
-                catch (Exception e)
+        private static void UpdateConfigFile(string latestCommitHash)
+        {
+            // Because config.xml exists in the new downloaded localization, we have to add the version element to it.
+            try
+            {
+                if (LocalizationTable.hash!=latestCommitHash)
                 {
-                    // Not a big deal:
-                    // Next time the LocalizationDownloader will force an update.
-                    UnityDebugger.Debugger.LogWarning("LocalizationDownloader", "Writing version in config.xml file failed: " + e.Message);
-                    throw;
+
                 }
+
+                string configPath = Path.Combine(LocalizationFolderPath, "config.json");
+                XmlDocument document = new XmlDocument();
+                document.Load(configPath);
+                XmlNode node = document.SelectSingleNode("//config");
+
+                XmlElement versionElement = document.CreateElement("version");
+                versionElement.SetAttribute("hash", latestCommitHash);
+                node.InsertBefore(versionElement, document.SelectSingleNode("//languages"));
+                document.Save(configPath);
+            }
+            catch (Exception e)
+            {
+                // Not a big deal:
+                // Next time the LocalizationDownloader will force an update.
+                UnityDebugger.Debugger.LogWarning("LocalizationDownloader", "Writing version in config.json file failed: " + e.Message);
+                throw;
             }
         }
 
@@ -295,56 +305,7 @@ namespace ProjectPorcupine.Localization
         /// </summary>
         private static string GetLocalizationVersionFromConfig()
         {
-            string localizationConfigFilePath = Path.Combine(LocalizationFolderPath, "config.xml");
-
-            string currentLocalizationVersion = null;
-            try
-            {
-                XmlReader reader = XmlReader.Create(localizationConfigFilePath);
-                while (reader.Read())
-                {
-                    if (reader.NodeType == XmlNodeType.Element && reader.Name == "version")
-                    {
-                        if (reader.HasAttributes)
-                        {
-                            currentLocalizationVersion = reader.GetAttribute("hash");
-                            break;
-                        }
-                    }
-                }
-
-                reader.Close();
-            }
-            catch (FileNotFoundException)
-            {
-                // It's fine - we will create that file later.
-                UnityDebugger.Debugger.Log("LocalizationDownloader", localizationConfigFilePath + " file not found, forcing an update.");
-            }
-            catch (DirectoryNotFoundException)
-            {
-                // This is probably first launch of the game.
-                UnityDebugger.Debugger.Log("LocalizationDownloader", LocalizationFolderPath + " folder not found, creating...");
-
-                try
-                {
-                    Directory.CreateDirectory(LocalizationFolderPath);
-                }
-                catch (Exception e)
-                {
-                    // If any exception happen here then we don't have a Localization folder in place
-                    // so we can just throw - we won't do anything good here.
-                    throw e;
-                }
-            }
-            catch (Exception e)
-            {
-                // i.e. UnauthorizedAccessException, NotSupportedException or UnauthorizedAccessException.
-                // Those should never happen and if they do something is really fucked up so we should
-                // probably start a fire, call 911 or at least throw an exception.
-                throw e;
-            }
-
-            return currentLocalizationVersion;
+            return LocalizationTable.hash;
         }
 
         /// <summary>

--- a/Assets/Scripts/Localization/LocalizationDownloader.cs
+++ b/Assets/Scripts/Localization/LocalizationDownloader.cs
@@ -108,13 +108,11 @@ namespace ProjectPorcupine.Localization
             // Because config.xml exists in the new downloaded localization, we have to add the version element to it.
             try
             {
-                if (LocalizationTable.hash!=latestCommitHash)
+                if (LocalizationTable.hash != latestCommitHash)
                 {
-
+                    string configPath = Path.Combine(LocalizationFolderPath, "config.json");
+                    LocalizationTable.SaveConfigFile(latestCommitHash, configPath);
                 }
-
-                string configPath = Path.Combine(LocalizationFolderPath, "config.json");
-                LocalizationTable.SaveConfigFile(latestCommitHash,configPath);
             }
             catch (Exception e)
             {
@@ -271,7 +269,7 @@ namespace ProjectPorcupine.Localization
                 // If there are files without that extension then:
                 // a) someone made a change to localization system and didn't update this
                 // b) We are in a wrong directory, so let's hope we didn't delete anything important.
-                if (file.Extension != ".lang" && file.Extension != ".meta" && file.Extension != ".ver" && file.Extension != ".md" && file.Name != "config.xml")
+                if (file.Extension != ".lang" && file.Extension != ".meta" && file.Extension != ".ver" && file.Extension != ".md" && file.Name != "config.json" && file.Name != "config.xml")
                 {
                     UnityDebugger.Debugger.LogError("LocalizationDownloader", "SOMETHING WENT HORRIBLY WRONG AT DOWNLOADING LOCALIZATION!");
                     throw new Exception("SOMETHING WENT HORRIBLY WRONG AT DOWNLOADING LOCALIZATION!");

--- a/Assets/Scripts/Localization/LocalizationDownloader.cs
+++ b/Assets/Scripts/Localization/LocalizationDownloader.cs
@@ -9,10 +9,8 @@
 using System;
 using System.Collections;
 using System.IO;
-using System.Xml;
 
 using ICSharpCode.SharpZipLib.Zip;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 
@@ -116,14 +114,7 @@ namespace ProjectPorcupine.Localization
                 }
 
                 string configPath = Path.Combine(LocalizationFolderPath, "config.json");
-                XmlDocument document = new XmlDocument();
-                document.Load(configPath);
-                XmlNode node = document.SelectSingleNode("//config");
-
-                XmlElement versionElement = document.CreateElement("version");
-                versionElement.SetAttribute("hash", latestCommitHash);
-                node.InsertBefore(versionElement, document.SelectSingleNode("//languages"));
-                document.Save(configPath);
+                LocalizationTable.SaveConfigFile(latestCommitHash,configPath);
             }
             catch (Exception e)
             {

--- a/Assets/Scripts/Localization/LocalizationLoader.cs
+++ b/Assets/Scripts/Localization/LocalizationLoader.cs
@@ -59,7 +59,7 @@ namespace ProjectPorcupine.Localization
             }
 
             // Load the localization config file first
-            LocalizationTable.LoadConfigFile(Path.Combine(filePath, "config.xml"));
+            LocalizationTable.LoadConfigFile(Path.Combine(filePath, "config.json"));
 
             // Loop through all files.
             // TODO: Think over the extension ".lang", might change that in the future.
@@ -84,12 +84,11 @@ namespace ProjectPorcupine.Localization
                 return;
             }
 
+            // Loads the localization table in to memory, checking for version.
+            UpdateLocalizationTable();
+
             // Update localization from the internet.
             StartCoroutine(LocalizationDownloader.CheckIfCurrentLocalizationIsUpToDate(delegate { UpdateLocalizationTable(); }));
-
-            // Even though it's ran again in start, UpdateLocalizationTable still needs ran here to actually have the chose language
-            // show on start, I don't really know why.
-            UpdateLocalizationTable();
         }
 
         private void Start()


### PR DESCRIPTION
This continues the path of getting XML data removed from the project. In this edition, we set the localization data to load a JSON file, and update said file upon completion.