### PR TITLE
Copper plates are available, copper wire isn't. Let's use copper plate

### DIFF
--- a/Assets/StreamingAssets/Data/Prototypes/Utility.json
+++ b/Assets/StreamingAssets/Data/Prototypes/Utility.json
@@ -20,13 +20,13 @@
         "Build": {
           "JobTime": 1.0,
           "Inventory": {
-            "copper_wire": 2
+            "copper_plate": 1
           }
         },
         "Deconstruct": {
           "JobTime": 1.0,
           "Inventory": {
-            "copper_wire": 1
+            "copper_plate": 1
           }
         }
       }


### PR DESCRIPTION
Right now we don't have a way to make copper wiring. Let's not use it for something so basic. We can reevaluate this at a later date if needed.