### PR TITLE
#155 BugFix

### DIFF
--- a/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
@@ -189,6 +189,7 @@ public class SettingsMenu : MonoBehaviour
         // Issue #155 Fix
         if (changesTracker.Count == 0)
         {
+            mainRoot.SetActive(false);
             return;
         }
 

--- a/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
@@ -185,12 +185,12 @@ public class SettingsMenu : MonoBehaviour
 
     public void Cancel()
     {
-		// If we have made no changes we can freely exit
-		// Issue #155 Fix
-		if (changesTracker.Count == 0)
-		{
-			return;
-		}
+        // If we have made no changes we can freely exit
+        // Issue #155 Fix
+        if (changesTracker.Count == 0)
+        {
+            return;
+        }
 
         // Open a dialog box to double check
         DialogBoxPromptOrInfo check;
@@ -205,7 +205,7 @@ public class SettingsMenu : MonoBehaviour
         }
         else
         {
-			// We can't display cancel box so just automatically cancel
+            // We can't display cancel box so just automatically cancel
             mainRoot.SetActive(false);
             return;
         }

--- a/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
@@ -6,7 +6,12 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
+
+// Since we modify some of the variables outside of this compilation unit
+// The 'field' is not assigned to and will always have it's default value
+// Will be true, thus we can disable this warning briefly.
 #pragma warning disable 0649
+
 using System.Collections.Generic;
 using System.Linq;
 using ProjectPorcupine.Localization;
@@ -180,6 +185,13 @@ public class SettingsMenu : MonoBehaviour
 
     public void Cancel()
     {
+		// If we have made no changes we can freely exit
+		// Issue #155 Fix
+		if (changesTracker.Count == 0)
+		{
+			return;
+		}
+
         // Open a dialog box to double check
         DialogBoxPromptOrInfo check;
 
@@ -193,6 +205,7 @@ public class SettingsMenu : MonoBehaviour
         }
         else
         {
+			// We can't display cancel box so just automatically cancel
             mainRoot.SetActive(false);
             return;
         }


### PR DESCRIPTION
Fixes #155 

I haven't been able to test this yet, but if one of you get the time before I do (I'll end up testing it tomorrow).

Currently do note that 'changes' means causing any element to update that could be toggling a switch on, then off again so it doesn't necessarily mean that you actually made changes but rather at minimum edited some of the values!

I'll probably also look at if I get the time actually telling the user what changes they have made i.e. something like;

```
Do you want to cancel

Changes Made:
  - Resolution: Low -> High
  - Sound Volume: 50 -> 55

    Yes               No
```

And in doing that I would fix the issue of making changes (but really actually not making any, like changing a value to 80 then back to 50 for example).