### PR TITLE
Removed references to BuildModeController.Instance

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
@@ -36,14 +36,11 @@ public class BuildModeController : IMouseHandler
 
     public BuildModeController()
     {
-        Instance = this;
         CurrentPreviewRotation = 0f;
         KeyboardManager.Instance.RegisterInputAction("RotateFurnitureLeft", KeyboardMappedInputType.KeyUp, RotateFurnitireLeft);
         KeyboardManager.Instance.RegisterInputAction("RotateFurnitureRight", KeyboardMappedInputType.KeyUp, RotateFurnitireRight);
         furnitureParent = new GameObject("Furniture Preview Sprites");
     }
-
-    public static BuildModeController Instance { get; protected set; }
 
     public float CurrentPreviewRotation { get; private set; }
 

--- a/Assets/Scripts/Controllers/InputOutput/MouseController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/MouseController.cs
@@ -138,7 +138,7 @@ namespace ProjectPorcupine.Mouse
         /// </summary>
         public MouseController()
         {
-            BuildModeController.Instance.SetMouseController(this);
+            WorldController.Instance.BuildModeController.SetMouseController(this);
             contextMenu = GameObject.FindObjectOfType<ContextMenu>();
             DragPreviewGameObjects = new List<GameObject>();
 
@@ -212,7 +212,14 @@ namespace ProjectPorcupine.Mouse
         {
             this.uiTooltip = null;
             mouseCursor.UIMode = false;
-            currentMode = BuildModeController.Instance.Building ? MouseMode.BUILD : MouseMode.COORDINATES;
+            if (WorldController.Instance.BuildModeController.Building)
+            {
+                currentMode = MouseMode.BUILD;
+            }
+            else
+            {
+                currentMode = MouseMode.COORDINATES;
+            }
 
             if (stopDragging)
             {

--- a/Assets/Scripts/Models/Inventory/Inventory.cs
+++ b/Assets/Scripts/Models/Inventory/Inventory.cs
@@ -241,7 +241,7 @@ public class Inventory : ISelectable, IContextActionProvider, IPrototypable
             {
                 LocalizationKey = "install_order",
                 RequireCharacterSelected = false,
-                Action = (cm, c) => BuildModeController.Instance.SetMode_BuildFurniture(Type, true)
+                Action = (cm, c) => WorldController.Instance.BuildModeController.SetMode_BuildFurniture(Type, true)
             };
         }
     }

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/MenuLeft.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/MenuLeft.cs
@@ -53,7 +53,7 @@ public class MenuLeft : MonoBehaviour
             if (CurrentlyOpen.name == "ConstructionMenu" || CurrentlyOpen.name == "OrderMenu")
             {
                 WorldController.Instance.SpawnInventoryController.SetUIVisibility(SettingsKeyHolder.DeveloperMode);
-                BuildModeController.Instance.Building = false;
+                WorldController.Instance.BuildModeController.Building = false;
             }
 
             WorldController.Instance.SoundController.OnButtonSFX();

--- a/Assets/StreamingAssets/CSharp/CommandFunctions.cs
+++ b/Assets/StreamingAssets/CSharp/CommandFunctions.cs
@@ -272,8 +272,8 @@ public static class CommandFunctions
         Tile t;
         if (ModUtils.GetTileAt(pos, out t))
         {
-            BuildModeController.Instance.SetBuildMode((BuildMode)buildMode, type, useCrated, false);
-            BuildModeController.Instance.DoBuild(t);
+            WorldController.Instance.BuildModeController.SetBuildMode((BuildMode)buildMode, type, useCrated, false);
+            WorldController.Instance.BuildModeController.DoBuild(t);
         }
     }
 


### PR DESCRIPTION
As the title says, this is to go along with #177.  This makes the decision that BuildModeController is only ever an instance since it requires a world to exist and can't exist independently of that.