### PR TITLE
Fix issue with spawning inventory one after each other

### DIFF
--- a/Assets/Scripts/Controllers/Events/SpawnInventoryController.cs
+++ b/Assets/Scripts/Controllers/Events/SpawnInventoryController.cs
@@ -80,6 +80,7 @@ public class SpawnInventoryController : IMouseHandler
         if (t.Inventory == null || t.Inventory.Type == InventoryToBuild)
         {
             World.Current.InventoryManager.PlaceInventory(t, CurrentInventory);
+            CurrentInventory = new Inventory(InventoryToBuild, AmountToCreate);
         }
     }
 


### PR DESCRIPTION
It would cause the inventory to spawn with `0` items.

This was due to the call to SpawnInventory invalidating the inventory that we passed.