### PR TITLE
Localization defaults for furniture, utilities, and inventory

### DIFF
--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -699,8 +699,8 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
         DragType = PrototypeReader.ReadJson(DragType, innerJson["DragType"]);
         isEnterableAction = PrototypeReader.ReadJson(isEnterableAction, innerJson["IsEnterableAction"]);
         getProgressInfoNameAction = PrototypeReader.ReadJson(getProgressInfoNameAction, innerJson["GetProgressInfoNameAction"]);
-        LocalizationName = PrototypeReader.ReadJson(LocalizationName, innerJson["LocalizationName"]);
-        LocalizationDescription = PrototypeReader.ReadJson(LocalizationDescription, innerJson["LocalizationDescription"]);
+        LocalizationName = PrototypeReader.ReadJson("furn_" + Type, innerJson["LocalizationName"]);
+        LocalizationDescription = PrototypeReader.ReadJson("furn_" + Type + "_desc", innerJson["LocalizationDescription"]);
 
         typeTags = new HashSet<string>(PrototypeReader.ReadJsonArray<string>(innerJson["TypeTags"]));
 
@@ -1175,7 +1175,7 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
             {
                 yield return new ContextMenuAction
                 {
-                    LocalizationKey = "prioritize_furniture",
+                    LocalizationKey = "prioritize",
                     LocalizationParameter = LocalizationName,
                     RequireCharacterSelected = true,
                     Action = (ca, c) => c.PrioritizeJob(Jobs[0])

--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -308,8 +308,8 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
         JToken innerJson = jsonProto.Value;
 
         typeTags = new HashSet<string>(PrototypeReader.ReadJsonArray<string>(innerJson["TypeTags"]));
-        LocalizationName = PrototypeReader.ReadJson(LocalizationName, innerJson["LocalizationName"]);
-        LocalizationDescription = PrototypeReader.ReadJson(LocalizationDescription, innerJson["LocalizationDescription"]);
+        LocalizationName = PrototypeReader.ReadJson("util_" + jsonProto.Name, innerJson["LocalizationName"]);
+        LocalizationDescription = PrototypeReader.ReadJson("util_" + jsonProto.Name + "_desc", innerJson["LocalizationDescription"]);
 
         tileTypeBuildPermissions = new HashSet<string>(PrototypeReader.ReadJsonArray<string>(innerJson["tileTypeBuildPermissions"]));
 

--- a/Assets/Scripts/Models/Inventory/Inventory.cs
+++ b/Assets/Scripts/Models/Inventory/Inventory.cs
@@ -276,8 +276,8 @@ public class Inventory : ISelectable, IContextActionProvider, IPrototypable
         MaxStackSize = PrototypeReader.ReadJson(50, innerJson["MaxStackSize"]);
         BasePrice = PrototypeReader.ReadJson(1f, innerJson["BasePrice"]);
         Category = PrototypeReader.ReadJson(Category, innerJson["Category"]);
-        LocalizationName = PrototypeReader.ReadJson(LocalizationName, innerJson["LocalizationName"]);
-        LocalizationDescription = PrototypeReader.ReadJson(LocalizationDescription, innerJson["LocalizationDescription"]);
+        LocalizationName = PrototypeReader.ReadJson("inv_" + Type, innerJson["LocalizationName"]);
+        LocalizationDescription = PrototypeReader.ReadJson("inv_" + Type + "_desc", innerJson["LocalizationDescription"]);
     }
 
     private void ImportPrototypeSettings(int defaulMaxStackSize, float defaultBasePrice, string defaultCategory)


### PR DESCRIPTION
Fixes #30 . Basically sets meaningful defaults for localization names to what is basically our schema for giving them names in the first place. I did test this out with Steel Wall, and it found the correct localization name. We could remove all of the default ones from the 3 files now if desired.