### PR TITLE
Total Gas is updated as the sum of all gas components

### DIFF
--- a/Assets/Scripts/Models/Area/AtmosphereComponent.cs
+++ b/Assets/Scripts/Models/Area/AtmosphereComponent.cs
@@ -150,6 +150,7 @@ public class AtmosphereComponent
         {
             gasses[gasName] += amount;
         }
+
         UpdateTotalGas();
     }
 
@@ -272,7 +273,10 @@ public class AtmosphereComponent
         destination.ThermalEnergy += thermalDelta;
     }
 
-    private void UpdateTotalGas()
+    /// <summary>
+    /// This should be called any time the gasses values change to update the total amount.
+    /// </summary>
+    public void UpdateTotalGas()
     {
         TotalGas = 0;
         foreach (float amount in gasses.Values)

--- a/Assets/Scripts/Models/Area/AtmosphereComponent.cs
+++ b/Assets/Scripts/Models/Area/AtmosphereComponent.cs
@@ -7,12 +7,9 @@
 // ====================================================
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using MoonSharp.Interpreter;
-using ProjectPorcupine.Rooms;
 using UnityEngine;
 
 /// <summary>
@@ -129,7 +126,7 @@ public class AtmosphereComponent
             gasses[gasNames[i]] += delta * GetGasFraction(gasNames[i]);
         }
 
-        TotalGas = newValue;
+        UpdateTotalGas();
         ThermalEnergy += delta * internalTemperature.InKelvin;
     }
 
@@ -147,14 +144,13 @@ public class AtmosphereComponent
 
         if (gasses[gasName] <= -amount)
         {
-            TotalGas -= gasses[gasName];
             gasses.Remove(gasName);
         }
         else
         {
-            TotalGas += amount;
             gasses[gasName] += amount;
         }
+        UpdateTotalGas();
     }
 
     /// <summary>
@@ -274,6 +270,15 @@ public class AtmosphereComponent
         float thermalDelta = amount * internalTemperature.InKelvin;
         this.ThermalEnergy -= thermalDelta;
         destination.ThermalEnergy += thermalDelta;
+    }
+
+    private void UpdateTotalGas()
+    {
+        TotalGas = 0;
+        foreach (float amount in gasses.Values)
+        {
+            TotalGas += amount;
+        }
     }
     #endregion
 


### PR DESCRIPTION
Fixes #196.

Basically what was happening is total gas was computed separately from the individual components. Due to floating point inaccuracies, sometimes the total gas could be less than 0. This should prevent that from happening.