### PR TITLE
Fixes a typo in the Furniture.json related to ValueBasedParamerName. …

### DIFF
--- a/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
+++ b/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
@@ -327,7 +327,7 @@ namespace ProjectPorcupine.Buildable.Components
         {
             public string Name { get; set; }
 
-            public string ValueBasedParamerName { get; set; }
+            public string ValueBasedParameterName { get; set; }
 
             public Conditions RunConditions { get; set; }
         }

--- a/Assets/Scripts/Models/Buildable/Components/Visuals.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Visuals.cs
@@ -63,7 +63,7 @@ namespace ProjectPorcupine.Buildable.Components
         {
             if (UsedAnimations != null && ParentFurniture.Animations != null && UsedAnimations.Count > 0)
             {
-                foreach (var anim in UsedAnimations)
+                foreach (UseAnimation anim in UsedAnimations)
                 {
                     if (!string.IsNullOrEmpty(anim.ValueBasedParamerName))
                     {
@@ -102,27 +102,6 @@ namespace ProjectPorcupine.Buildable.Components
             
             ParentFurniture.Changed += FurnitureChanged;
             ParentFurniture.IsOperatingChanged += (furniture) => SetDefaultAnimation(furniture.IsOperating);
-
-            if (!IsValid())
-            {
-                UnityDebugger.Debugger.LogError("Visuals", "Error found in animation for " + SpriteName);
-            }
-        }
-
-        protected bool IsValid()
-        {
-            if (UsedAnimations != null)
-            {
-                foreach (UseAnimation anim in UsedAnimations)
-                {
-                    if (anim.RunConditions == null)
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
         }
 
         private void FurnitureChanged(Furniture obj)

--- a/Assets/Scripts/Models/Buildable/Components/Visuals.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Visuals.cs
@@ -65,12 +65,12 @@ namespace ProjectPorcupine.Buildable.Components
             {
                 foreach (UseAnimation anim in UsedAnimations)
                 {
-                    if (!string.IsNullOrEmpty(anim.ValueBasedParamerName))
+                    if (!string.IsNullOrEmpty(anim.ValueBasedParameterName))
                     {
                         // is value based animation
                         if (ParentFurniture.Animations != null)
                         {
-                            int frmIdx = FurnitureParams[anim.ValueBasedParamerName].ToInt();
+                            int frmIdx = FurnitureParams[anim.ValueBasedParameterName].ToInt();
                             ParentFurniture.Animations.SetFrameIndex(frmIdx);
                         }
                     }

--- a/Assets/StreamingAssets/Data/Prototypes/Furniture.json
+++ b/Assets/StreamingAssets/Data/Prototypes/Furniture.json
@@ -635,7 +635,7 @@
           "UseAnimation": [
             {
               "Name": "filling",
-              "ValueBasedParameterName": "fluid_storage_index"
+              "ValueBasedParamerName": "fluid_storage_index"
             }
           ]
         },
@@ -1342,7 +1342,7 @@
           "UseAnimation": [
             {
               "Name": "accumulate",
-              "ValueBasedParameterName": "pow_accumulator_index"
+              "ValueBasedParamerName": "pow_accumulator_index"
             }
           ]
         },

--- a/Assets/StreamingAssets/Data/Prototypes/Furniture.json
+++ b/Assets/StreamingAssets/Data/Prototypes/Furniture.json
@@ -635,7 +635,7 @@
           "UseAnimation": [
             {
               "Name": "filling",
-              "ValueBasedParamerName": "fluid_storage_index"
+              "ValueBasedParameterName": "fluid_storage_index"
             }
           ]
         },
@@ -1342,7 +1342,7 @@
           "UseAnimation": [
             {
               "Name": "accumulate",
-              "ValueBasedParamerName": "pow_accumulator_index"
+              "ValueBasedParameterName": "pow_accumulator_index"
             }
           ]
         },


### PR DESCRIPTION
Fixes #126 

Basically there should either be a ValueBasedParamerName or a RunCondition. Both is okay, but will default to the ValueBasedParamerName. If neither exist, this crash can occur.

I'm going to add in an explicit check for this in a future PR, as well as the ability to better debug these kinds of issues, but I wanted to get this in ASAP.