### PR TITLE
Fixes crash when no output stations and input runs out

### DIFF
--- a/Assets/Scripts/Models/Buildable/Components/Workshop.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Workshop.cs
@@ -264,13 +264,12 @@ namespace ProjectPorcupine.Buildable.Components
                     CurrentProcessingTime.ChangeFloatValue(deltaTime * efficiency);
                     IsRunning.SetValue(true);
 
-                    if (CurrentProcessingTime.ToFloat() >=
-                        MaxProcessingTime.ToFloat())
+                    if (CurrentProcessingTime.ToFloat() >= MaxProcessingTime.ToFloat())
                     {
                         List<TileObjectTypeAmount> outPlacement = CheckForInventoryAtOutput(prodChain);
 
                         // if output placement was found for all products, place them
-                        if (outPlacement.Count == prodChain.Output.Count)
+                        if (outPlacement.Count == 0 || outPlacement.Count == prodChain.Output.Count)
                         {
                             PlaceInventories(outPlacement);
                             //// processing done, can fetch input for another processing

--- a/Assets/Scripts/Models/Buildable/Components/Workshop.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Workshop.cs
@@ -496,7 +496,7 @@ namespace ProjectPorcupine.Buildable.Components
 
             // processing is done, try to spit the output
             // check if output can be placed in world
-            if (prodChain != null)
+            if (prodChain != null && prodChain.Output != null)
             {
                 foreach (Item outObjType in prodChain.Output)
                 {


### PR DESCRIPTION
Fixes #135 

Basically what is happening is there is no output for a water generator in the .json, as the outputs are utilities, not products. When it goes to check to see if there is any outputs, it crashes. This puts a check for that condition, and will return nothing if there is no outputs, allowing it to still function.