### PR TITLE
Fix to occasional issue with settings menu not correctly clearing modality

### DIFF
--- a/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
@@ -186,9 +186,10 @@ public class SettingsMenu : MonoBehaviour
     public void Cancel()
     {
         // If we have made no changes we can freely exit
-        // Issue #155 Fix
         if (changesTracker.Count == 0)
         {
+            currentCategory = string.Empty;
+            GameController.Instance.IsModal = false;
             mainRoot.SetActive(false);
             return;
         }
@@ -207,6 +208,9 @@ public class SettingsMenu : MonoBehaviour
         else
         {
             // We can't display cancel box so just automatically cancel
+            changesTracker.Clear();
+            currentCategory = string.Empty;
+            GameController.Instance.IsModal = false;
             mainRoot.SetActive(false);
             return;
         }


### PR DESCRIPTION
This could occur for example if you can't show the cancel box (which arguably can't occur in any of our scenes) but could also occur occasionally if you pressed cancel without selecting changes (slipped through out testing).  Also clears the current category and the change tracker in the case where it can't show the cancel box.