### PR TITLE
Fixed localization bug

### DIFF
--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -98,7 +98,14 @@ namespace ProjectPorcupine.Localization
 
             if (localizationTable.ContainsKey(language) && localizationTable[language].TryGetValue(key, out value))
             {
-                return string.Format(value, additionalValues);
+                try
+                {
+                    return string.Format(value, additionalValues);
+                }
+                catch (FormatException)
+                {
+                    Debug.LogWarning("Bad localization for " + key + ". Arguments found: " + additionalValues.Length);
+                }
             }
 
             if (!missingKeysLogged.Contains(key) && key != string.Empty && IsNumber(key))

--- a/Assets/Scripts/Models/Inventory/Inventory.cs
+++ b/Assets/Scripts/Models/Inventory/Inventory.cs
@@ -242,6 +242,7 @@ public class Inventory : ISelectable, IContextActionProvider, IPrototypable
             yield return new ContextMenuAction
             {
                 LocalizationKey = "install_order",
+                LocalizationParameter = LocalizationName,
                 RequireCharacterSelected = false,
                 Action = (cm, c) => WorldController.Instance.BuildModeController.SetMode_BuildFurniture(Type, true)
             };


### PR DESCRIPTION
Formatting localization could sometimes fail if the wrong number of arguments were present. This now no longer outright fails, and also fixes one of the instances of missing localization arguments.