### PR TITLE
Context menus now show up for the right Z-level.

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/MouseController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/MouseController.cs
@@ -797,7 +797,9 @@ namespace ProjectPorcupine.Mouse
                     }
                     else if (mouseKey == 1)
                     {
-                        Tile t = WorldController.Instance.GetTileAtWorldCoord(position);
+                        Vector3 mousePosition = position;
+                        mousePosition.z = WorldController.Instance.CameraController.CurrentLayer;
+                        Tile t = WorldController.Instance.GetTileAtWorldCoord(mousePosition);
                         if (WorldController.Instance.MouseController.contextMenu != null && t != null)
                         {
                             if (WorldController.Instance.MouseController.IsPanning)


### PR DESCRIPTION
A bug existed to only show the 0 level, due to only using the 2-d mouse index. Changed this to use the z-level correctly, and it now works!