### PR TITLE
Gas connections will not function outside.

### DIFF
--- a/Assets/Scripts/Models/Buildable/Components/GasConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/GasConnection.cs
@@ -57,24 +57,27 @@ namespace ProjectPorcupine.Buildable.Components
 
         public override bool CanFunction()
         {
-            bool canFunction = true;
-
             // check if all requirements are fullfilled
-            if (Requires != null && Requires.Count > 0)
+            if (Requires != null && Requires.Count > 0 && ParentFurniture.Tile.Room != null)
             {
                 Room room = ParentFurniture.Tile.Room;
+                if (room.IsOutsideRoom())
+                {
+                    return false;
+                }
+
                 foreach (GasInfo reqGas in Requires)
                 {
                     // get actual gas pressure so it matches what gas really is, not the prettified version for display
                     float curGasPressure = room.GetGasPressure(reqGas.Gas);
                     if (curGasPressure < reqGas.MinLimit || curGasPressure > reqGas.MaxLimit)
                     {
-                        canFunction = false;
+                        return false;
                     }
                 }
             }
 
-            return canFunction;
+            return true;
         }
 
         public override void FixedFrequencyUpdate(float deltaTime)


### PR DESCRIPTION
Fixes #229 

A gas generator, or anything requiring gas, shouldn't function outside.