### PR TITLE
[Conflicted] Make all lower-bar menus closable by pressing the button that opened them

### DIFF
--- a/Assets/Scripts/UI/DialogBox/DialogBox.cs
+++ b/Assets/Scripts/UI/DialogBox/DialogBox.cs
@@ -50,6 +50,18 @@ public class DialogBox : MonoBehaviour
         gameObject.SetActive(false);
     }
 
+    public void ToggleDialog()
+    {
+        if (gameObject.activeSelf == false)
+        {
+            ShowDialog();
+        }
+        else
+        {
+            CloseDialog();
+        }
+    }
+
     public void SetClosedAction(string funcName)
     {
         Closed = () => FunctionsManager.Get("ModDialogBox").Call(funcName, Result); 

--- a/Assets/Scripts/UI/DialogBox/DialogBoxManager.cs
+++ b/Assets/Scripts/UI/DialogBox/DialogBoxManager.cs
@@ -73,7 +73,9 @@ public class DialogBoxManager : MonoBehaviour
             dialogBoxQuests = tempGoObj.GetComponent<DialogBoxQuests>();
             DialogBoxes["Quests"] = dialogBoxQuests;
             AddQuestList();
+
             LoadModdedDialogBoxes();
+
             AddMainMenuItems();
         }
     }
@@ -114,7 +116,7 @@ public class DialogBoxManager : MonoBehaviour
     {
         GameMenuManager.Instance.AddMenuItem(
             "menu_work",
-            () => dialogBoxJobList.ShowDialog(),
+            () => dialogBoxJobList.ToggleDialog(),
             "menu_construction");
 
         GameMenuManager.Instance.AddMenuItem(
@@ -124,15 +126,12 @@ public class DialogBoxManager : MonoBehaviour
 
         GameMenuManager.Instance.AddMenuItem(
             "menu_quests",
-            () => dialogBoxQuests.ShowDialog(),
+            () => dialogBoxQuests.ToggleDialog(),
             "menu_world");
 
         GameMenuManager.Instance.AddMenuItem(
             "menu_options",
-            () =>
-            {
-                dialogBoxOptions.ShowDialog();
-            },
+            () => dialogBoxOptions.ToggleDialog(),
             "menu_quests");
     }
 

--- a/Assets/Scripts/UI/DialogBox/JobList/DialogBoxJobList.cs
+++ b/Assets/Scripts/UI/DialogBox/JobList/DialogBoxJobList.cs
@@ -27,7 +27,7 @@ public class DialogBoxJobList : DialogBox
 
         foreach (Character character in World.Current.CharacterManager)
         {
-            GameObject go = (GameObject)Instantiate(JobListItemPrefab, JobList);
+            GameObject go = Instantiate(JobListItemPrefab, JobList);
             string jobDescription = LocalizationTable.GetLocalization(character.GetJobDescription(), formatValues);
             go.GetComponentInChildren<Text>().text = string.Format("<b>{0}</b> - {1}", character.GetName(), jobDescription);
 

--- a/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
+++ b/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
@@ -64,11 +64,7 @@ public class GameMenuController : MonoBehaviour
         Button button = gameObject.GetComponent<Button>();
         button.onClick.AddListener(delegate
             {
-                if (!GameController.Instance.IsModal)
-                {
-                    DeactivateAll();
-                    gameMenuItem.Trigger();
-                }
+                gameMenuItem.Trigger();
             });
 
         Action localizationFilesChangedHandler = null;

--- a/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuManager.cs
+++ b/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuManager.cs
@@ -129,10 +129,7 @@ public class GameMenuManager : IEnumerable<GameMenuItem>
     /// <returns>Each menu item.</returns>
     IEnumerator<GameMenuItem> IEnumerable<GameMenuItem>.GetEnumerator()
     {
-        foreach (GameMenuItem menuItem in menuItems)
-        {
-            yield return menuItem;
-        }
+        return menuItems.GetEnumerator();
     }
 
     /// <summary>
@@ -150,12 +147,13 @@ public class GameMenuManager : IEnumerable<GameMenuItem>
     /// <param name="position">The position of the menu item just added.</param>
     private void AddFromItemsToAdd(string key, int position)
     {
-        if (itemsToAdd.ContainsKey(key) && itemsToAdd[key].Count > 0)
+        List<GameMenuItem> items;
+        if (itemsToAdd.TryGetValue(key, out items))
         {
-            for (int i = itemsToAdd[key].Count - 1; i >= 0; i--)
+            for (int i = items.Count - 1; i >= 0; i--)
             {
-                GameMenuItem menuItem = itemsToAdd[key][i];
-                itemsToAdd[key].RemoveAt(i);
+                GameMenuItem menuItem = items[i];
+                items.RemoveAt(i);
                 AddMenuItem(menuItem, position + 1);
             }
         }

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/MenuLeft.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/MenuLeft.cs
@@ -14,7 +14,7 @@ public class MenuLeft : MonoBehaviour
     // This is the parent of the menus.
     private Transform parent;
 
-    public GameObject CurrentlyOpen { get; private set; }
+    private GameObject CurrentlyOpen { get; set; }
 
     // Use this for initialization
     public void Start()
@@ -28,16 +28,18 @@ public class MenuLeft : MonoBehaviour
         GameMenuManager.Instance.AddMenuItem("menu_orders", () => OnMenuButtonClicked(orderMenu), 1);
     }
 
-    public void OpenMenuCurrentMenu()
+    public void OpenMenu(GameObject menu)
     {
-        CurrentlyOpen.GetComponent<SlideAnimation>().Show();
+        // So that we don't have two menus open at the same time
+        CloseCurrentMenu();
+
+        menu.GetComponent<SlideAnimation>().Show();
 
         WorldController.Instance.SoundController.OnButtonSFX();
+        
+        WorldController.Instance.SpawnInventoryController.SetUIVisibility(false);
 
-        if (CurrentlyOpen.name == "ConstructionMenu" || CurrentlyOpen.name == "OrderMenu")
-        {
-            WorldController.Instance.SpawnInventoryController.SetUIVisibility(false);
-        }
+        CurrentlyOpen = menu;
     }
 
     public void CloseCurrentMenu()
@@ -45,15 +47,14 @@ public class MenuLeft : MonoBehaviour
         if (CurrentlyOpen != null)
         {
             CurrentlyOpen.GetComponent<SlideAnimation>().Hide();
-
-            if (CurrentlyOpen.name == "ConstructionMenu" || CurrentlyOpen.name == "OrderMenu")
-            {
-                WorldController.Instance.SpawnInventoryController.SetUIVisibility(SettingsKeyHolder.DeveloperMode);
-                WorldController.Instance.BuildModeController.Building = false;
-            }
+            
+            WorldController.Instance.SpawnInventoryController.SetUIVisibility(SettingsKeyHolder.DeveloperMode);
+            WorldController.Instance.BuildModeController.Building = false;
 
             WorldController.Instance.SoundController.OnButtonSFX();
         }
+
+        CurrentlyOpen = null;
     }
 
     // Use this function to add all the menus.
@@ -73,12 +74,11 @@ public class MenuLeft : MonoBehaviour
     {
         if (CurrentlyOpen == menu)
         {
-            CurrentlyOpen = null;
+            CloseCurrentMenu();
         }
         else
         {
-            CurrentlyOpen = menu;
-            OpenMenuCurrentMenu();
+            OpenMenu(menu);
         }
     }
 }


### PR DESCRIPTION
### What this PR does

Makes it so that all menus in the lower bar can be closed again by pressing the button that opened it again.

### TODO

- [ ] Fix so that the Options menu can't be toggled when the settings menu is open (But for now this seems like a resonable temporary trade-off for getting a more convenient menu system).
