### PR TITLE
Replaced a lot of ContainsKey calls with TryGetValue calls

### DIFF
--- a/Assets/Editor/UnitTests/Models/Functions/LuaFunctionsTest.cs
+++ b/Assets/Editor/UnitTests/Models/Functions/LuaFunctionsTest.cs
@@ -78,10 +78,10 @@ public class LuaFunctionsTest
     {
         // This makes sure that the channel lua is activated since we require to to be
         // we set it back to the old value afterwards as to not annoy the 'dev'
-        bool oldVal = true;
-        if (UnityDebugger.Debugger.Channels.ContainsKey("Lua"))
+        bool oldVal;
+        if (UnityDebugger.Debugger.Channels.TryGetValue("Lua", out oldVal) == false)
         {
-            oldVal = UnityDebugger.Debugger.Channels["Lua"];
+            oldVal = true;
         }
 
         UnityDebugger.Debugger.Channels["Lua"] = true;

--- a/Assets/Scripts/Controllers/InputOutput/SoundController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/SoundController.cs
@@ -122,13 +122,12 @@ public class SoundController
         }
 
         clip.SetCooldown(cooldownTime);
-        if (!AudioManager.channelGroups.ContainsKey(chanGroup))
+        ChannelGroup channelGroup;
+        if (AudioManager.channelGroups.TryGetValue(chanGroup, out channelGroup) == false)
         {
-            chanGroup = "master";
+            channelGroup = AudioManager.channelGroups["master"];
         }
-
-        ChannelGroup channelGroup = AudioManager.channelGroups[chanGroup];
-
+        
         FMOD.System soundSystem = AudioManager.SoundSystem;
         Channel channel;
         soundSystem.playSound(clip.Get(), channelGroup, true, out channel);
@@ -268,9 +267,10 @@ public class SoundController
 
     public void SetVolume(string channel, float volume)
     {
-        if (AudioManager.channelGroups.ContainsKey(channel))
+        ChannelGroup group;
+        if (AudioManager.channelGroups.TryGetValue(channel, out group))
         {
-            AudioManager.channelGroups[channel].setVolume(volume);
+            group.setVolume(volume);
         }
         else
         {
@@ -285,10 +285,11 @@ public class SoundController
 
     public float GetVolume(string channel)
     {
-        if (AudioManager.channelGroups.ContainsKey(channel))
+        ChannelGroup group;
+        if (AudioManager.channelGroups.TryGetValue(channel, out group))
         {
             float volume = 0;
-            AudioManager.channelGroups[channel].getVolume(out volume);
+            group.getVolume(out volume);
             return volume;
         }
         else

--- a/Assets/Scripts/Controllers/Sprites/CharacterSpriteController.cs
+++ b/Assets/Scripts/Controllers/Sprites/CharacterSpriteController.cs
@@ -128,14 +128,13 @@ namespace ProjectPorcupine.Entities
                 }
             }
 
-            if (objectGameObjectMap.ContainsKey(character) == false)
+            GameObject char_go;
+            if (objectGameObjectMap.TryGetValue(character, out char_go) == false)
             {
                 UnityDebugger.Debugger.LogError("CharacterSpriteController", "OnCharacterChanged -- trying to change visuals for character not in our map.");
                 return;
             }
-
-            GameObject char_go = objectGameObjectMap[character];
-
+            
             char_go.transform.position = new Vector3(character.X, character.Y, character.Z);
 
             if (character.IsSelected)

--- a/Assets/Scripts/Controllers/Sprites/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/Sprites/FurnitureSpriteController.cs
@@ -206,14 +206,13 @@ public class FurnitureSpriteController : BaseSpriteController<Furniture>
     protected override void OnChanged(Furniture furn)
     {
         // Make sure the furniture's graphics are correct.
-        if (objectGameObjectMap.ContainsKey(furn) == false)
+        GameObject furn_go;
+        if (objectGameObjectMap.TryGetValue(furn, out furn_go) == false)
         {
             UnityDebugger.Debugger.LogError("FurnitureSpriteController", "OnFurnitureChanged -- trying to change visuals for furniture not in our map.");
             return;
         }
-
-        GameObject furn_go = objectGameObjectMap[furn];
-
+        
         if (furn.HasTypeTag("Door"))
         {
             // Check to see if we actually have a wall north/south, and if so
@@ -254,7 +253,8 @@ public class FurnitureSpriteController : BaseSpriteController<Furniture>
 
     protected override void OnRemoved(Furniture furn)
     {
-        if (objectGameObjectMap.ContainsKey(furn) == false)
+        GameObject furn_go;
+        if (objectGameObjectMap.TryGetValue(furn, out furn_go) == false)
         {
             UnityDebugger.Debugger.LogError("FurnitureSpriteController", "OnFurnitureRemoved -- trying to change visuals for furniture not in our map.");
             return;
@@ -263,15 +263,9 @@ public class FurnitureSpriteController : BaseSpriteController<Furniture>
         furn.Changed -= OnChanged;
         furn.Removed -= OnRemoved;
         furn.IsOperatingChanged -= OnIsOperatingChanged;
-        GameObject furn_go = objectGameObjectMap[furn];
         objectGameObjectMap.Remove(furn);
         GameObject.Destroy(furn_go);
-
-        if (childObjectMap.ContainsKey(furn) == false)
-        {
-            return;
-        }
-
+        
         childObjectMap.Remove(furn);
     }
 
@@ -282,12 +276,13 @@ public class FurnitureSpriteController : BaseSpriteController<Furniture>
             return;
         }
 
-        if (childObjectMap.ContainsKey(furniture) == false)
+        FurnitureChildObjects childObjects;
+        if (childObjectMap.TryGetValue(furniture, out childObjects) == false)
         {
             return;
         }
-
-        UpdateIconObjectsVisibility(furniture, childObjectMap[furniture]);
+        
+        UpdateIconObjectsVisibility(furniture, childObjects);
     }
 
     private void UpdateIconObjectsVisibility(Furniture furniture, FurnitureChildObjects statuses)

--- a/Assets/Scripts/Controllers/Sprites/InventorySpriteController.cs
+++ b/Assets/Scripts/Controllers/Sprites/InventorySpriteController.cs
@@ -132,13 +132,13 @@ public sealed class InventorySpriteController : BaseSpriteController<Inventory>
     protected override void OnChanged(Inventory inventory)
     {
         // Make sure the furniture's graphics are correct.
-        if (objectGameObjectMap.ContainsKey(inventory) == false)
+        GameObject inventoryGameObject;
+        if (objectGameObjectMap.TryGetValue(inventory, out inventoryGameObject) == false)
         {
             UnityDebugger.Debugger.LogError("InventorySpriteController", "OnCharacterChanged -- trying to change visuals for inventory not in our map.");
             return;
         }
-
-        GameObject inventoryGameObject = objectGameObjectMap[inventory];
+        
         if (inventory.StackSize > 0)
         {
             Text text = inventoryGameObject.GetComponentInChildren<Text>();

--- a/Assets/Scripts/Controllers/Sprites/JobSpriteController.cs
+++ b/Assets/Scripts/Controllers/Sprites/JobSpriteController.cs
@@ -69,6 +69,9 @@ public class JobSpriteController : BaseSpriteController<Job>
             return;
         }
 
+        // This is weird why do we have this here?
+        // OnCreated should not be called twice for a given job?
+        // This seems like there is a bug hiding somewhere
         if (objectGameObjectMap.ContainsKey(job))
         {
             return;

--- a/Assets/Scripts/Controllers/Sprites/UtilitySpriteController.cs
+++ b/Assets/Scripts/Controllers/Sprites/UtilitySpriteController.cs
@@ -99,21 +99,21 @@ public class UtilitySpriteController : BaseSpriteController<Utility>
     protected override void OnChanged(Utility util)
     {
         // Make sure the utility's graphics are correct.
-        if (objectGameObjectMap.ContainsKey(util) == false)
+        GameObject util_go;
+        if (objectGameObjectMap.TryGetValue(util, out util_go) == false)
         {
             UnityDebugger.Debugger.LogError("UtilitySpriteController", "OnUtilityChanged -- trying to change visuals for utility not in our map.");
             return;
         }
-
-        GameObject util_go = objectGameObjectMap[util];
-
+        
         util_go.GetComponent<SpriteRenderer>().sprite = GetSpriteForUtility(util);
         util_go.GetComponent<SpriteRenderer>().color = util.Tint;
     }
         
     protected override void OnRemoved(Utility util)
     {
-        if (objectGameObjectMap.ContainsKey(util) == false)
+        GameObject util_go;
+        if (objectGameObjectMap.TryGetValue(util, out util_go) == false)
         {
             UnityDebugger.Debugger.LogError("UtilitySpriteController", "OnUtilityRemoved -- trying to change visuals for utility not in our map.");
             return;
@@ -121,7 +121,6 @@ public class UtilitySpriteController : BaseSpriteController<Utility>
 
         util.Changed -= OnChanged;
         util.Removed -= OnRemoved;
-        GameObject util_go = objectGameObjectMap[util];
         objectGameObjectMap.Remove(util);
         GameObject.Destroy(util_go);
     }

--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -129,7 +129,7 @@ namespace ProjectPorcupine.Localization
         public static string GetLocalizaitonCodeLocalization(string code)
         {
             LocalizationData localizationData;
-            if (localizationConfigurations.TryGetValue(code, out localizationData) == false )
+            if (localizationConfigurations.TryGetValue(code, out localizationData) == false)
             {
                 UnityDebugger.Debugger.Log("LocalizationTable", "name of " + code + " is not present in config file.");
                 return code;

--- a/Assets/Scripts/Models/Animation/FurnitureAnimation.cs
+++ b/Assets/Scripts/Models/Animation/FurnitureAnimation.cs
@@ -98,18 +98,19 @@ namespace Animation
         /// </summary>
         public void SetState(string stateName)
         {
-            if (animations.ContainsKey(stateName) == false)
-            {
-                return;
-            }
-
             if (stateName == currentAnimationState)
             {
                 return;
             }
 
+            SpritenameAnimation animation;
+            if (animations.TryGetValue(stateName, out animation) == false)
+            {
+                return;
+            }
+
             currentAnimationState = stateName;
-            currentAnimation = animations[currentAnimationState];
+            currentAnimation = animation;
             currentAnimation.Play();
             ShowSprite(currentAnimation.CurrentFrameName);                       
         }

--- a/Assets/Scripts/Models/Area/AtmosphereComponent.cs
+++ b/Assets/Scripts/Models/Area/AtmosphereComponent.cs
@@ -78,7 +78,14 @@ public class AtmosphereComponent
     /// <param name="gasName">Gas you want the pressure of.</param>
     public float GetGasAmount(string gasName)
     {
-        return gasses.ContainsKey(gasName) ? gasses[gasName] : 0;
+        float amount;
+
+        if (gasses.TryGetValue(gasName, out amount) == false)
+        {
+            amount = 0;
+        }
+
+        return amount;
     }
 
     /// <summary>
@@ -137,18 +144,21 @@ public class AtmosphereComponent
     /// <param name="amount"> The amount to update by. </param>
     public void ChangeGas(string gasName, float amount)
     {
-        if (gasses.ContainsKey(gasName) == false)
+        float gasAmount;
+        if (gasses.TryGetValue(gasName, out gasAmount))
         {
-            gasses[gasName] = 0;
+            if (gasAmount <= -amount)
+            {
+                gasses.Remove(gasName);
+            }
+            else
+            {
+                gasses[gasName] = gasAmount + amount;
+            }
         }
-
-        if (gasses[gasName] <= -amount)
+        else if (amount > 0)
         {
-            gasses.Remove(gasName);
-        }
-        else
-        {
-            gasses[gasName] += amount;
+            gasses[gasName] = amount;
         }
 
         UpdateTotalGas();

--- a/Assets/Scripts/Models/Area/Room.cs
+++ b/Assets/Scripts/Models/Area/Room.cs
@@ -268,6 +268,7 @@ namespace ProjectPorcupine.Rooms
             return boundaryTiles;
         }
 
+        // FIXME: 'Has' methods are generally a bad idea, should be 'TryGet' instead
         public bool HasRoomBehavior(string behaviorKey)
         {
             return RoomBehaviors.ContainsKey(behaviorKey);

--- a/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
+++ b/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
@@ -108,9 +108,9 @@ namespace ProjectPorcupine.Buildable.Components
 
             string componentTypeName = jtoken["Component"]["Type"].ToString();
 
-            if (componentTypes.ContainsKey(componentTypeName))
+            Type t;
+            if (componentTypes.TryGetValue(componentTypeName, out t))
             {
-                Type t = componentTypes[componentTypeName];
                 BuildableComponent component = (BuildableComponent)jtoken["Component"].ToObject(t);
 
                 // need to set name explicitly (not part of deserialization as it's passed in)
@@ -133,10 +133,10 @@ namespace ProjectPorcupine.Buildable.Components
 
             JProperty componentProperty = (JProperty)componentToken;
             string componentTypeName = componentProperty.Name;
-            if (componentTypes.ContainsKey(componentTypeName))
+            Type t;
+            if (componentTypes.TryGetValue(componentTypeName, out t))
             {
-                Type t = componentTypes[componentTypeName];
-                t.GetType(); 
+                // t.GetType();
 
                 BuildableComponent component = (BuildableComponent)componentProperty.Value.ToObject(t);
 

--- a/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
+++ b/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
@@ -106,13 +106,13 @@ namespace ProjectPorcupine.Buildable.Components
                 componentTypes = FindComponentsInAssembly();
             }
 
-            JToken jComponent = jtoken["Component"];
-            string componentTypeName = jComponent["Type"].ToString();
+            JToken jcomponent = jtoken["Component"];
+            string componentTypeName = jcomponent["Type"].ToString();
 
             Type t;
             if (componentTypes.TryGetValue(componentTypeName, out t))
             {
-                BuildableComponent component = (BuildableComponent)jComponent.ToObject(t);
+                BuildableComponent component = (BuildableComponent)jcomponent.ToObject(t);
 
                 // need to set name explicitly (not part of deserialization as it's passed in)
                 component.Type = componentTypeName;

--- a/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
+++ b/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
@@ -106,12 +106,13 @@ namespace ProjectPorcupine.Buildable.Components
                 componentTypes = FindComponentsInAssembly();
             }
 
-            string componentTypeName = jtoken["Component"]["Type"].ToString();
+            JToken jComponent = jtoken["Component"];
+            string componentTypeName = jComponent["Type"].ToString();
 
             Type t;
             if (componentTypes.TryGetValue(componentTypeName, out t))
             {
-                BuildableComponent component = (BuildableComponent)jtoken["Component"].ToObject(t);
+                BuildableComponent component = (BuildableComponent)jComponent.ToObject(t);
 
                 // need to set name explicitly (not part of deserialization as it's passed in)
                 component.Type = componentTypeName;
@@ -136,8 +137,6 @@ namespace ProjectPorcupine.Buildable.Components
             Type t;
             if (componentTypes.TryGetValue(componentTypeName, out t))
             {
-                // t.GetType();
-
                 BuildableComponent component = (BuildableComponent)componentProperty.Value.ToObject(t);
 
                 // need to set name explicitly (not part of deserialization as it's passed in)

--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -242,9 +242,9 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
         // buddy.  Just trigger their OnChangedCallback.
         foreach (Tile neighbor in obj.Tile.GetNeighbours())
         {
-            if (neighbor.Utilities != null && neighbor.Utilities.ContainsKey(obj.Type))
+            Utility utility;
+            if (neighbor.Utilities != null && neighbor.Utilities.TryGetValue(obj.Type, out utility))
             {
-                Utility utility = neighbor.Utilities[obj.Type];
                 if (utility.Changed != null)
                 {
                     utility.Changed(utility);
@@ -385,9 +385,9 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
         // Just trigger their OnChangedCallback.
         foreach (Tile neighbor in Tile.GetNeighbours())
         {
-            if (neighbor.Utilities != null && neighbor.Utilities.ContainsKey(this.Type))
+            Utility neighborUtility;
+            if (neighbor.Utilities != null && neighbor.Utilities.TryGetValue(this.Type, out neighborUtility))
             {
-                Utility neighborUtility = neighbor.Utilities[this.Type];
                 if (neighborUtility.Changed != null)
                 {
                     neighborUtility.Changed(neighborUtility);
@@ -565,10 +565,9 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
         {
             foreach (Tile neighborTile in utilityToUpdate.Tile.GetNeighbours())
             {
-                if (neighborTile != null && neighborTile.Utilities != null && neighborTile.Utilities.ContainsKey(this.Type))
+                Utility utility;
+                if (neighborTile != null && neighborTile.Utilities != null && neighborTile.Utilities.TryGetValue(this.Type, out utility))
                 {
-                    Utility utility = neighborTile.Utilities[this.Type];
-
                     if (utility.Grid != null && utilityToUpdate.Grid == null)
                     {
                         utilityToUpdate.Grid = utility.Grid;
@@ -602,9 +601,9 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
         {
             if (neighborTile != null && neighborTile.Utilities != null)
             {
-                if (neighborTile != null && neighborTile.Utilities != null && neighborTile.Utilities.ContainsKey(this.Type))
+                Utility utility;
+                if (neighborTile != null && neighborTile.Utilities != null && neighborTile.Utilities.TryGetValue(this.Type, out utility))
                 {
-                    Utility utility = neighborTile.Utilities[this.Type];
                     utility.UpdateGrid(utility, utilityToUpdate.Grid);
                 }
             }

--- a/Assets/Scripts/Models/Events/EventAction.cs
+++ b/Assets/Scripts/Models/Events/EventAction.cs
@@ -67,12 +67,14 @@ public class EventActions
     /// <param name="luaFunc">Lua function to add to list of actions.</param>
     public void Register(string actionName, string luaFunc)
     {
-        if (!actionsList.ContainsKey(actionName) || actionsList[actionName] == null)
+        List<string> actions;
+        if (actionsList.TryGetValue(actionName, out actions) == false || actions == null)
         {
-            actionsList[actionName] = new List<string>();
+            actions = new List<string>();
+            actionsList[actionName] = actions;
         }
 
-        actionsList[actionName].Add(luaFunc);
+        actions.Add(luaFunc);
     }
 
     /// <summary>
@@ -82,12 +84,13 @@ public class EventActions
     /// <param name="luaFunc">Lua function to add to list of actions.</param>
     public void Deregister(string actionName, string luaFunc)
     {
-        if (!actionsList.ContainsKey(actionName) || actionsList[actionName] == null)
+        List<string> actions;
+        if (actionsList.TryGetValue(actionName, out actions) == false || actions == null)
         {
             return;
         }
 
-        actionsList[actionName].Remove(luaFunc);
+        actions.Remove(luaFunc);
     }
 
     /// <summary>
@@ -99,12 +102,10 @@ public class EventActions
     /// <param name="parameters">Parameters in question.  First one must be target instance. </param>
     public void Trigger(string actionName, params object[] parameters)
     {
-        if (!actionsList.ContainsKey(actionName) || actionsList[actionName] == null)
+        List<string> actions;
+        if (actionsList.TryGetValue(actionName, out actions) && actions != null)
         {
-        }
-        else
-        {
-            FunctionsManager.Get(parameters[0].GetType().Name).Call(actionsList[actionName], parameters);
+            FunctionsManager.Get(parameters[0].GetType().Name).Call(actions, parameters);
         }
     }
 
@@ -115,6 +116,7 @@ public class EventActions
     /// <param name="actionName">Action name.</param>
     public bool HasEvent(string actionName)
     {
+        // FIXME: 'Has' methods are generally a bad idea, should be 'TryGet' instead
         return actionsList.ContainsKey(actionName);
     }
 

--- a/Assets/Scripts/Models/Functions/CSharpFunctions.cs
+++ b/Assets/Scripts/Models/Functions/CSharpFunctions.cs
@@ -51,11 +51,13 @@ public class CSharpFunctions : IFunctions
         return assembly.GetType().FullName.EndsWith("AssemblyBuilder") || assembly.Location == null || assembly.Location == string.Empty;
     }
 
+    // FIXME: 'Has' methods are generally a bad idea, should be 'TryGet' instead
     public bool HasFunction(string name)
     {
         return methods.ContainsKey(name);
     }
 
+    // FIXME: 'Has' methods are generally a bad idea, should be 'TryGet' instead
     public bool HasConstructor(string className)
     {
         return constructors.ContainsKey(className);

--- a/Assets/Scripts/Models/Functions/FunctionsManager.cs
+++ b/Assets/Scripts/Models/Functions/FunctionsManager.cs
@@ -133,12 +133,13 @@ public static class FunctionsManager
             return null;
         }
 
-        if (actions.ContainsKey(name))
+        Functions functions;
+        if (actions.TryGetValue(name, out functions) == false)
         {
-            return actions[name];
+            return null;
         }
 
-        return null;
+        return functions;
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/Functions/Parameter.cs
+++ b/Assets/Scripts/Models/Functions/Parameter.cs
@@ -78,13 +78,14 @@ public class Parameter
     {
         get
         {
-            if (contents.ContainsKey(key) == false)
+            Parameter param;
+            if (contents.TryGetValue(key, out param) == false)
             {
-                // Add a new blank key to contents, that will then be returned.
-                contents.Add(key, new Parameter(key));
+                param = new Parameter(key);
+                contents.Add(key, param);
             }
-
-            return contents[key];
+            
+            return param;
         }
 
         set
@@ -174,6 +175,7 @@ public class Parameter
         return keys;
     }
 
+    // FIXME: ContainsKey should be avoided in favor of TryGetValue!
     public bool ContainsKey(string key)
     {
         return contents.ContainsKey(key);

--- a/Assets/Scripts/Models/InputOutput/AudioManager.cs
+++ b/Assets/Scripts/Models/InputOutput/AudioManager.cs
@@ -88,24 +88,15 @@ public static class AudioManager
     /// <returns>SoundClip from the specified category with the specified name.</returns>
     public static SoundClip GetAudio(string categoryName, string audioName)
     {
-        SoundClip clip;
-
         string audioNameAndCategory = categoryName + "/" + audioName;
-
-        if (audioClips.ContainsKey(audioNameAndCategory))
-        {
-            clip = audioClips[audioNameAndCategory];
-        }
-        else
+        
+        SoundClip clip;
+        if (audioClips.TryGetValue(audioNameAndCategory, out clip) == false)
         {
             try
             {
                 UnityDebugger.Debugger.LogWarning("AudioManager", "No audio available called: " + audioNameAndCategory);
-                if (audioClips.ContainsKey("Sound/Error"))
-                {
-                    clip = audioClips["Sound/Error"];
-                }
-                else
+                if (audioClips.TryGetValue("Sound/Error", out clip) == false)
                 {
                     UnityDebugger.Debugger.LogError("AudioManager", "Error audio not available!!!");
                     clip = null;
@@ -177,13 +168,15 @@ public static class AudioManager
 
             filename = audioCategory + "/" + filename;
 
-            if (audioClips.ContainsKey(filename))
+            SoundClip soundClip;
+            if (audioClips.TryGetValue(filename, out soundClip))
             {
-                audioClips[filename].Add(clip);
+                soundClip.Add(clip);
             }
             else
             {
-                audioClips[filename] = new SoundClip(clip);
+                soundClip = new SoundClip(clip);
+                audioClips[filename] = soundClip;
             }
         }
     }

--- a/Assets/Scripts/Models/InputOutput/ModsManager.cs
+++ b/Assets/Scripts/Models/InputOutput/ModsManager.cs
@@ -103,9 +103,10 @@ public class ModsManager
         {
             foreach (Action<JProperty> handler in prototypeHandler.Value)
             {
-                if (tagNameToProperty.ContainsKey(prototypeHandler.Key))
+                JToken token;
+                if (tagNameToProperty.TryGetValue(prototypeHandler.Key, out token))
                 {
-                    foreach (JToken prototypeGroup in tagNameToProperty[prototypeHandler.Key])
+                    foreach (JToken prototypeGroup in token)
                     {
                         handler((JProperty)prototypeGroup);
                     }
@@ -234,13 +235,15 @@ public class ModsManager
     /// <param name="prototypesLoader">Called to handle the prototypes loading.</param>
     private void HandlePrototypes(string prototypeKey, Action<JProperty> prototypesLoader)
     {
-        if (!prototypeHandlers.ContainsKey(prototypeKey))
+        List<Action<JProperty>> handlers;
+        if (prototypeHandlers.TryGetValue(prototypeKey, out handlers) == false)
         {
-            prototypeHandlers.Add(prototypeKey, new List<Action<JProperty>>());
+            handlers = new List<Action<JProperty>>();
+            prototypeHandlers.Add(prototypeKey, handlers);
         }
 
         // The way these work suggest it should be in a separate class, either a new class (PrototypeLoader?) or in one of the prototype related classes
-        prototypeHandlers[prototypeKey].Add(prototypesLoader);
+        handlers.Add(prototypesLoader);
     }
 
     private void LoadPrototypes()

--- a/Assets/Scripts/Models/InputOutput/SpriteManager.cs
+++ b/Assets/Scripts/Models/InputOutput/SpriteManager.cs
@@ -106,6 +106,9 @@ public static class SpriteManager
     /// <param name="spriteName">Sprite name.</param>
     public static bool HasSprite(string categoryName, string spriteName)
     {
+        // NOTE! This method is a bad idea. Every time we want to know
+        // if a sprite exists we always want the sprite too
+        // So it's wastefull to check before
         Dictionary<string, Sprite> categorySprites;
         if (sprites.TryGetValue(categoryName, out categorySprites))
         {

--- a/Assets/Scripts/Models/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Models/Inventory/InventoryManager.cs
@@ -47,12 +47,14 @@ public class InventoryManager
 
     public void RegisterInventoryTypeCreated(InventoryOfTypeCreated func, string type)
     {
-        if (inventoryTypeCreated.ContainsKey(type) == false)
+        List<InventoryOfTypeCreated> inventories;
+        if (inventoryTypeCreated.TryGetValue(type, out inventories) == false)
         {
-            inventoryTypeCreated[type] = new List<InventoryOfTypeCreated>();
+            inventories = new List<InventoryOfTypeCreated>();
+            inventoryTypeCreated[type] = inventories;
         }
 
-        inventoryTypeCreated[type].Add(func);
+        inventories.Add(func);
     }
 
     public void UnregisterInventoryTypeCreated(InventoryOfTypeCreated func, string type)
@@ -136,12 +138,14 @@ public class InventoryManager
         // We may also have to create a new stack on the tile, if the startTile was previously empty.
         if (tileWasEmpty)
         {
-            if (Inventories.ContainsKey(tile.Inventory.Type) == false)
+            List<Inventory> inventories;
+            if (Inventories.TryGetValue(tile.Inventory.Type, out inventories) == false)
             {
-                Inventories[tile.Inventory.Type] = new List<Inventory>();
+                inventories = new List<Inventory>();
+                Inventories[tile.Inventory.Type] = inventories;
             }
 
-            Inventories[tile.Inventory.Type].Add(tile.Inventory);
+            inventories.Add(tile.Inventory);
             InvokeInventoryCreated(tile.Inventory);
         }
 
@@ -174,12 +178,13 @@ public class InventoryManager
         }
 
         // Check that there is a target to transfer to
-        if (job.DeliveredItems.ContainsKey(sourceInventory.Type) == false)
+        Inventory targetInventory;
+        if (job.DeliveredItems.TryGetValue(sourceInventory.Type, out targetInventory) == false)
         {
-            job.DeliveredItems[sourceInventory.Type] = new Inventory(sourceInventory.Type, 0, sourceInventory.MaxStackSize);
+            targetInventory = new Inventory(sourceInventory.Type, 0, sourceInventory.MaxStackSize);
+            job.DeliveredItems[sourceInventory.Type] = targetInventory;
         }
 
-        Inventory targetInventory = job.DeliveredItems[sourceInventory.Type];
         int transferAmount = Mathf.Min(targetInventory.MaxStackSize - targetInventory.StackSize, sourceInventory.StackSize);
 
         sourceInventory.StackSize -= transferAmount;
@@ -198,12 +203,15 @@ public class InventoryManager
         {
             character.Inventory = sourceInventory.Clone();
             character.Inventory.StackSize = 0;
-            if (Inventories.ContainsKey(character.Inventory.Type) == false)
+
+            List<Inventory> inventories;
+            if (Inventories.TryGetValue(character.Inventory.Type, out inventories) == false)
             {
-                Inventories[character.Inventory.Type] = new List<Inventory>();
+                inventories = new List<Inventory>();
+                Inventories[character.Inventory.Type] = inventories;
             }
 
-            Inventories[character.Inventory.Type].Add(character.Inventory);
+            inventories.Add(character.Inventory);
         }
         else if (character.Inventory.Type != sourceInventory.Type)
         {
@@ -274,29 +282,20 @@ public class InventoryManager
 
     public bool HasInventoryOfType(string type, bool canTakeFromStockpile)
     {
-        if (Inventories.ContainsKey(type) == false || Inventories[type].Count == 0)
+        List<Inventory> inventories;
+        if (Inventories.TryGetValue(type, out inventories) == false || inventories.Count == 0)
         {
             return false;
         }
 
-        return Inventories[type].Find(inventory => inventory.CanBePickedUp(canTakeFromStockpile)) != null;
+        return inventories.Find(inventory => inventory.CanBePickedUp(canTakeFromStockpile)) != null;
     }
 
     public bool HasInventoryOfType(string[] types, bool canTakeFromStockpile)
     {
-        // Test that we have records for any of the types
-        List<string> filteredTypes = types
-            .ToList()
-            .FindAll(type => Inventories.ContainsKey(type) && Inventories[type].Count > 0);
-
-        if (filteredTypes.Count == 0)
+        foreach (string objectType in types)
         {
-            return false;
-        }
-
-        foreach (string objectType in filteredTypes)
-        {
-            if (Inventories[objectType].Find(inventory => inventory.CanBePickedUp(canTakeFromStockpile)) != null)
+            if (HasInventoryOfType(objectType, canTakeFromStockpile))
             {
                 return true;
             }
@@ -362,21 +361,10 @@ public class InventoryManager
 
     public void InventoryAvailable(Inventory inventory)
     {
-        if (inventoryTypeCreated.ContainsKey(inventory.Type))
+        List<InventoryOfTypeCreated> inventories;
+        if (inventoryTypeCreated.TryGetValue(inventory.Type, out inventories))
         {
-            List<InventoryOfTypeCreated> remove = new List<InventoryOfTypeCreated>();
-            foreach (InventoryOfTypeCreated func in inventoryTypeCreated[inventory.Type])
-            {
-                if (func(inventory))
-                {
-                    remove.Add(func);
-                }
-            }
-
-            foreach (InventoryOfTypeCreated func in remove)
-            {
-                inventoryTypeCreated[inventory.Type].Remove(func);
-            }
+            inventories.RemoveAll(func => func(inventory));
         }
     }
 
@@ -387,9 +375,10 @@ public class InventoryManager
             return;
         }
 
-        if (Inventories.ContainsKey(inventory.Type))
+        List<Inventory> inventories;
+        if (Inventories.TryGetValue(inventory.Type, out inventories))
         {
-            Inventories[inventory.Type].Remove(inventory);
+            inventories.Remove(inventory);
         }
 
         if (inventory.Tile != null)

--- a/Assets/Scripts/Models/Job/Job.cs
+++ b/Assets/Scripts/Models/Job/Job.cs
@@ -459,7 +459,8 @@ public class Job : ISelectable
 
         foreach (RequestedItem item in RequestedItems.Values)
         {
-            if (DeliveredItems.ContainsKey(item.Type) == false || item.AmountNeeded(DeliveredItems[item.Type]) > 0)
+            Inventory inventory;
+            if (DeliveredItems.TryGetValue(item.Type, out inventory) == false || item.AmountNeeded(inventory) > 0)
             {
                 return false;
             }
@@ -475,13 +476,19 @@ public class Job : ISelectable
 
     public int AmountDesiredOfInventoryType(string type)
     {
-        if (RequestedItems.ContainsKey(type) == false)
+        RequestedItem requestedItem;
+        if (RequestedItems.TryGetValue(type, out requestedItem) == false)
         {
             return 0;
         }
 
-        Inventory inventory = DeliveredItems.ContainsKey(type) ? DeliveredItems[type] : null;
-        return RequestedItems[type].AmountDesired(inventory);
+        Inventory inventory;
+        if (DeliveredItems.TryGetValue(type, out inventory) == false)
+        {
+            inventory = null;
+        }
+
+        return requestedItem.AmountDesired(inventory);
     }
 
     public bool IsRequiredInventoriesAvailable()
@@ -541,7 +548,11 @@ public class Job : ISelectable
     {
         foreach (RequestedItem item in RequestedItems.Values)
         {
-            Inventory inventory = DeliveredItems.ContainsKey(item.Type) ? DeliveredItems[item.Type] : null;
+            Inventory inventory;
+            if (DeliveredItems.TryGetValue(item.Type, out inventory) == false)
+            {
+                inventory = null;
+            }
 
             if (item.DesiresMore(inventory))
             {

--- a/Assets/Scripts/Models/Keyboard/KeyboardManager.cs
+++ b/Assets/Scripts/Models/Keyboard/KeyboardManager.cs
@@ -115,9 +115,10 @@ public class KeyboardManager
     /// </summary>
     public void TriggerActionIfValid(string inputName)
     {
-        if (mapping.ContainsKey(inputName))
+        KeyboadMappedInput mappedInput;
+        if (mapping.TryGetValue(inputName, out mappedInput))
         {
-            mapping[inputName].TriggerActionIfInputValid();
+            mappedInput.TriggerActionIfInputValid();
         }
     }
 
@@ -136,10 +137,11 @@ public class KeyboardManager
 
     public void RegisterInputAction(string inputName, KeyboardMappedInputType inputType, Action onTrigger)
     {
-        if (mapping.ContainsKey(inputName))
+        KeyboadMappedInput mappedInput;
+        if (mapping.TryGetValue(inputName, out mappedInput))
         {
-            mapping[inputName].OnTrigger = onTrigger;
-            mapping[inputName].Type = inputType;
+            mappedInput.OnTrigger = onTrigger;
+            mappedInput.Type = inputType;
         }
         else
         {
@@ -156,18 +158,16 @@ public class KeyboardManager
 
     public void UnRegisterInputAction(string inputName)
     {
-        if (mapping.ContainsKey(inputName))
-        {
-            mapping.Remove(inputName);
-        }
+        mapping.Remove(inputName);
     }
 
     public void RegisterInputMapping(string inputName, KeyboardInputModifier inputModifiers, params KeyCode[] keyCodes)
     {
-        if (mapping.ContainsKey(inputName))
+        KeyboadMappedInput mappedInput;
+        if (mapping.TryGetValue(inputName, out mappedInput))
         {
-            mapping[inputName].Modifiers = inputModifiers;
-            mapping[inputName].AddKeyCodes(keyCodes);
+            mappedInput.Modifiers = inputModifiers;
+            mappedInput.AddKeyCodes(keyCodes);
         }
         else
         {

--- a/Assets/Scripts/Models/OrderActions/OrderAction.cs
+++ b/Assets/Scripts/Models/OrderActions/OrderAction.cs
@@ -57,10 +57,10 @@ namespace ProjectPorcupine.OrderActions
 
             string orderActionType = orderActionProp.Name;
 
-            if (orderActionTypes.ContainsKey(orderActionType))
+            Type t;
+            if (orderActionTypes.TryGetValue(orderActionType, out t))
             {
                 JToken innerJson = orderActionProp.Value;
-                Type t = orderActionTypes[orderActionType];
 
                 OrderAction orderAction = (OrderAction)orderActionProp.Value.ToObject(t);
                 orderAction.Type = orderActionProp.Name;

--- a/Assets/Scripts/Models/Prototypes/PrototypeMap.cs
+++ b/Assets/Scripts/Models/Prototypes/PrototypeMap.cs
@@ -81,9 +81,21 @@ public class PrototypeMap<T> where T : IPrototypable, new()
     /// </summary>
     /// <returns><c>true</c> if there is a prototype with the specified type; otherwise, <c>false</c>.</returns>
     /// <param name="type">The prototype type.</param>
+    [System.Obsolete("Has is deprecated, please use TryGet instead")]
     public bool Has(string type)
     {
         return prototypes.ContainsKey(type);
+    }
+
+    /// <summary>
+    /// Tries to get a specified prototype.
+    /// </summary>
+    /// <param name="type">The prototype type.</param>
+    /// <param name="val">The prototype.</param>
+    /// <returns><c>true</c> if there is a prototype with the specified type; otherwise, <c>false</c>.</returns>
+    public bool TryGet(string type, out T val)
+    {
+        return prototypes.TryGetValue(type, out val);
     }
 
     /// <summary>
@@ -93,9 +105,10 @@ public class PrototypeMap<T> where T : IPrototypable, new()
     /// <param name="type">The prototype type.</param>
     public T Get(string type)
     {
-        if (Has(type))
+        T prot;
+        if (prototypes.TryGetValue(type, out prot))
         {
-            return prototypes[type];
+            return prot;
         }
 
         return default(T);
@@ -116,9 +129,10 @@ public class PrototypeMap<T> where T : IPrototypable, new()
     /// <param name="proto">The prototype instance.</param>
     public void Add(T proto)
     {
-        if (Has(proto.Type))
+        T oldProto;
+        if (TryGet(proto.Type, out oldProto))
         {
-            UnityDebugger.Debugger.LogWarningFormat("PrototypeMap", "Trying to register a prototype of type '{0}' which already exists. Overwriting.", proto.Type);
+            UnityDebugger.Debugger.LogWarningFormat("PrototypeMap", "Trying to register a prototype of type '{0}' which already exists. Overwriting. Old value: {1}", proto.Type, oldProto);
         }
 
         Set(proto);

--- a/Assets/Scripts/Models/Settings/Settings.cs
+++ b/Assets/Scripts/Models/Settings/Settings.cs
@@ -59,20 +59,10 @@ public static class Settings
             return;
         }
 
-        // If we already have a setting with the same name,
-        if (settingsDict.ContainsKey(key))
-        {
-            // update the setting.
-            settingsDict.Remove(key);
-            settingsDict.Add(key, value);
-            UnityDebugger.Debugger.Log("Settings", "Updated setting : " + key + " to value of " + value);
-        }
-        else
-        {
-            // add a new setting to the dict.
-            settingsDict.Add(key, value);
-            UnityDebugger.Debugger.Log("Settings", "Created new setting : " + key + " to value of " + value);
-        }
+        // If there wasn't a setting already, we are creating a new one
+        bool new_setting = settingsDict.Remove(key) == false;
+        settingsDict.Add(key, value);
+        UnityDebugger.Debugger.Log("Settings", (new_setting ? "Created new setting : " : "Updated setting : ") + key + " to value of " + value);
     }
 
     public static bool GetSetting<T>(string key, out T result)

--- a/Assets/Scripts/Models/Ships/ShipManager.cs
+++ b/Assets/Scripts/Models/Ships/ShipManager.cs
@@ -102,7 +102,8 @@ public class ShipManager
     /// <param name="berth">The berth furniture object.</param>
     public bool IsOccupied(Furniture berth)
     {
-        return berthShipMap.ContainsKey(berth) && berthShipMap[berth] != null;
+        Ship ship;
+        return berthShipMap.TryGetValue(berth, out ship) && ship != null;
     }
 
     /// <summary>
@@ -111,7 +112,13 @@ public class ShipManager
     /// <param name="berth">The berth furniture object.</param>
     public Ship GetBerthedShip(Furniture berth)
     {
-        return berthShipMap.ContainsKey(berth) ? berthShipMap[berth] : null;
+        Ship ship;
+        if (berthShipMap.TryGetValue(berth, out ship) == false || ship == null)
+        {
+            return null;
+        }
+
+        return ship;
     }
 
     /// <summary>
@@ -137,14 +144,16 @@ public class ShipManager
     /// <param name="berth">The berth furniture object.</param>
     public void DeberthShip(Furniture berth)
     {
-        if (berthShipMap.ContainsKey(berth) == false || berthShipMap[berth] == null)
+        Ship ship;
+        if (berthShipMap.TryGetValue(berth, out ship) == false || ship  == null)
         {
             UnityDebugger.Debugger.LogError("Ships", "No ship berthed here: " + berth.Tile.ToString());
             return;
         }
 
-        berthShipMap[berth].State = ShipState.WRAPPED;
-        berthShipMap[berth].Wrap();
+        ship.State = ShipState.WRAPPED;
+        ship.Wrap();
+
         berthShipMap[berth] = null;
 
         berth.EventActions.Trigger("OnDeberth", berth);

--- a/Assets/Scripts/Models/Trade/Wallet.cs
+++ b/Assets/Scripts/Models/Trade/Wallet.cs
@@ -31,9 +31,10 @@ public class Wallet
     {
         get
         {
-            if (currencies.ContainsKey(name))
+            Currency currency;
+            if (currencies.TryGetValue(name, out currency))
             {
-                return currencies[name];
+                return currency;
             }
 
             return null;

--- a/Assets/Scripts/Pathfinding/Cache.cs
+++ b/Assets/Scripts/Pathfinding/Cache.cs
@@ -12,39 +12,43 @@ using System;
 
 namespace ProjectPorcupine.Pathfinding
 {
-    // This class will only work with reference types. If this should support value types it needs to use Nullable<T>
-    public class CircularBuffer<T> where T : class
-    {
-        private T[] buffer;
-        private int index;
-
-        public CircularBuffer(int size)
-        {
-            buffer = new T[size];
-            index = 0;
-        }
-
-        public T Enqueue(T newValue)
-        {
-            // Remove all references to this value and then add the value
-            IEqualityComparer<T> comparer = EqualityComparer<T>.Default;
-            for (int i = 0; i < buffer.Length; i++)
-            {
-                if (comparer.Equals(buffer[i], newValue))
-                {
-                    buffer[i] = default(T);
-                }
-            }
-
-            index = (index + 1) % buffer.Length;
-            T oldValue = buffer[index];
-            buffer[index] = newValue;
-            return oldValue;
-        }
-    }
-
     public class Cache
     {
+        /// <summary>
+        /// A fixed size circular buffer used by the pathfinding cache.
+        /// </summary>
+        /// <remarks>This class will only work with reference types. If this should support value types it needs to use Nullable<T>.</remarks>
+        /// <typeparam name="T">The type stored.</typeparam>
+        public class CircularBuffer<T> where T : class
+        {
+            private T[] buffer;
+            private int index;
+
+            public CircularBuffer(int size)
+            {
+                buffer = new T[size];
+                index = 0;
+            }
+
+            public T Enqueue(T newValue)
+            {
+                // Remove all references to this value and then add the value
+                IEqualityComparer<T> comparer = EqualityComparer<T>.Default;
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    if (comparer.Equals(buffer[i], newValue))
+                    {
+                        buffer[i] = default(T);
+                    }
+                }
+
+                index = (index + 1) % buffer.Length;
+                T oldValue = buffer[index];
+                buffer[index] = newValue;
+                return oldValue;
+            }
+        }
+
         private const int MaxCacheSize = 20;
         
         private CircularBuffer<CacheKey> oldPaths;

--- a/Assets/Scripts/Pathfinding/Cache.cs
+++ b/Assets/Scripts/Pathfinding/Cache.cs
@@ -146,6 +146,5 @@ namespace ProjectPorcupine.Pathfinding
                 return oldValue;
             }
         }
-
     }
 }

--- a/Assets/Scripts/Pathfinding/Cache.cs
+++ b/Assets/Scripts/Pathfinding/Cache.cs
@@ -8,47 +8,11 @@
 #endregion
 using System.Collections.Generic;
 using System.Linq;
-using System;
 
 namespace ProjectPorcupine.Pathfinding
 {
     public class Cache
     {
-        /// <summary>
-        /// A fixed size circular buffer used by the pathfinding cache.
-        /// </summary>
-        /// <remarks>This class will only work with reference types. If this should support value types it needs to use Nullable<T>.</remarks>
-        /// <typeparam name="T">The type stored.</typeparam>
-        public class CircularBuffer<T> where T : class
-        {
-            private T[] buffer;
-            private int index;
-
-            public CircularBuffer(int size)
-            {
-                buffer = new T[size];
-                index = 0;
-            }
-
-            public T Enqueue(T newValue)
-            {
-                // Remove all references to this value and then add the value
-                IEqualityComparer<T> comparer = EqualityComparer<T>.Default;
-                for (int i = 0; i < buffer.Length; i++)
-                {
-                    if (comparer.Equals(buffer[i], newValue))
-                    {
-                        buffer[i] = default(T);
-                    }
-                }
-
-                index = (index + 1) % buffer.Length;
-                T oldValue = buffer[index];
-                buffer[index] = newValue;
-                return oldValue;
-            }
-        }
-
         private const int MaxCacheSize = 20;
         
         private CircularBuffer<CacheKey> oldPaths;
@@ -147,5 +111,41 @@ namespace ProjectPorcupine.Pathfinding
                 return bx.GetHashCode();
             }
         }
+
+        /// <summary>
+        /// A fixed size circular buffer used by the pathfinding cache.
+        /// </summary>
+        /// <remarks>This class will only work with reference types. If this should support value types it needs to use Nullable<T>.</remarks>
+        /// <typeparam name="T">The type stored.</typeparam>
+        public class CircularBuffer<T> where T : class
+        {
+            private T[] buffer;
+            private int index;
+
+            public CircularBuffer(int size)
+            {
+                buffer = new T[size];
+                index = 0;
+            }
+
+            public T Enqueue(T newValue)
+            {
+                // Remove all references to this value and then add the value
+                IEqualityComparer<T> comparer = EqualityComparer<T>.Default;
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    if (comparer.Equals(buffer[i], newValue))
+                    {
+                        buffer[i] = default(T);
+                    }
+                }
+
+                index = (index + 1) % buffer.Length;
+                T oldValue = buffer[index];
+                buffer[index] = newValue;
+                return oldValue;
+            }
+        }
+
     }
 }

--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -54,15 +54,14 @@ public class Path_AStar
         Dictionary<Tile, Path_Node<Tile>> nodes = world.tileGraph.nodes;
 
         // Make sure our start/end tiles are in the list of nodes!
-        if (nodes.ContainsKey(tileStart) == false)
+        Path_Node<Tile> start;
+        if (nodes.TryGetValue(tileStart, out start) == false)
         {
             UnityDebugger.Debugger.LogError("Path_AStar", "The starting tile isn't in the list of nodes!");
 
             return;
         }
-
-        Path_Node<Tile> start = nodes[tileStart];
-
+        
         /*
          * Mostly following this pseusocode:
          * https://en.wikipedia.org/wiki/A*_search_algorithm
@@ -263,14 +262,14 @@ public class Path_AStar
         Queue<Tile> total_path = new Queue<Tile>();
         total_path.Enqueue(current.data); // This "final" step is the path is the goal!
 
-        while (came_From.ContainsKey(current))
+        // Effectivly: current = came_From[current]
+        while (came_From.TryGetValue(current, out current))
         {
             /*    Came_From is a map, where the
             *    key => value relation is real saying
             *    some_node => we_got_there_from_this_node
             */
-
-            current = came_From[current];
+            
             total_path.Enqueue(current.data);
         }
 

--- a/Assets/Scripts/UI/DialogBox/DialogBoxManager.cs
+++ b/Assets/Scripts/UI/DialogBox/DialogBoxManager.cs
@@ -84,10 +84,11 @@ public class DialogBoxManager : MonoBehaviour
     /// <param name="dialogName">The name of the dialog (a.k.a. the title of the dialog).</param>
     public DialogBox ShowDialogBoxByName(string dialogName)
     {
-        if (DialogBoxes.ContainsKey(dialogName))
+        DialogBox dialog;
+        if (DialogBoxes.TryGetValue(dialogName, out dialog))
         {
-            DialogBoxes[dialogName].ShowDialog();
-            return DialogBoxes[dialogName];
+            dialog.ShowDialog();
+            return dialog;
         }
         else
         {

--- a/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuManager.cs
+++ b/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuManager.cs
@@ -105,12 +105,15 @@ public class GameMenuManager : IEnumerable<GameMenuItem>
         else
         {
             GameMenuItem menuItem = new GameMenuItem(key, callback);
-            if (itemsToAdd.ContainsKey(afterKey) == false)
+
+            List<GameMenuItem> items;
+            if (itemsToAdd.TryGetValue(afterKey, out items) == false)
             {
-                itemsToAdd[afterKey] = new List<GameMenuItem>();
+                items = new List<GameMenuItem>();
+                itemsToAdd[afterKey] = items;
             }
 
-            itemsToAdd[afterKey].Add(menuItem);
+            items.Add(menuItem);
         }
     }
 
@@ -150,12 +153,13 @@ public class GameMenuManager : IEnumerable<GameMenuItem>
     /// <param name="position">The position of the menu item just added.</param>
     private void AddFromItemsToAdd(string key, int position)
     {
-        if (itemsToAdd.ContainsKey(key) && itemsToAdd[key].Count > 0)
+        List<GameMenuItem> items;
+        if (itemsToAdd.TryGetValue(key, out items) && items.Count > 0)
         {
-            for (int i = itemsToAdd[key].Count - 1; i >= 0; i--)
+            for (int i = items.Count - 1; i >= 0; i--)
             {
-                GameMenuItem menuItem = itemsToAdd[key][i];
-                itemsToAdd[key].RemoveAt(i);
+                GameMenuItem menuItem = items[i];
+                items.RemoveAt(i);
                 AddMenuItem(menuItem, position + 1);
             }
         }

--- a/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
@@ -77,14 +77,17 @@ public class SettingsMenu : MonoBehaviour
             return;
         }
 
+        Dictionary<string, BaseSettingsElement[]> option;
+
         // Optimisation for saving
-        if (instance.currentCategory != string.Empty && instance.currentCategory != category && instance.options.ContainsKey(instance.currentCategory))
+        if (instance.currentCategory != string.Empty && instance.currentCategory != category && instance.options.TryGetValue(instance.currentCategory, out option))
         {
-            foreach (string headingName in instance.options[instance.currentCategory].Keys)
+            foreach (string headingName in option.Keys)
             {
-                for (int i = 0; i < instance.options[instance.currentCategory][headingName].Length; i++)
+                BaseSettingsElement[] settingsElements = option[headingName];
+                for (int i = 0; i < settingsElements.Length; i++)
                 {
-                    BaseSettingsElement elementCopy = instance.options[instance.currentCategory][headingName][i];
+                    BaseSettingsElement elementCopy = settingsElements[i];
 
                     if (elementCopy != null && elementCopy.valueChanged)
                     {
@@ -120,26 +123,22 @@ public class SettingsMenu : MonoBehaviour
                 button.SelectColor();
             }
         }
-
-        if (instance.options.ContainsKey(category) == false)
+        
+        if (instance.currentCategory != string.Empty && instance.options.TryGetValue(category, out option))
         {
-            return;
-        }
-
-        if (instance.currentCategory != string.Empty && instance.options.ContainsKey(instance.currentCategory))
-        {
-            foreach (string headingName in instance.options[instance.currentCategory].Keys)
+            foreach (string headingName in option.Keys)
             {
                 // Create heading prefab
                 SettingsHeading heading = Instantiate(instance.headingPrefab).GetComponent<SettingsHeading>();
                 heading.SetText(headingName);
                 heading.transform.SetParent(instance.elementRoot.transform);
 
-                for (int i = 0; i < instance.options[instance.currentCategory][headingName].Length; i++)
+                BaseSettingsElement[] settingsElements = option[headingName];
+                for (int i = 0; i < settingsElements.Length; i++)
                 {
-                    if (instance.options[instance.currentCategory][headingName][i] != null)
+                    if (settingsElements[i] != null)
                     {
-                        BaseSettingsElement element = instance.options[instance.currentCategory][headingName][i];
+                        BaseSettingsElement element = settingsElements[i];
                         GameObject go = element.InitializeElement();
                         TooltipComponent tc = go.AddComponent<TooltipComponent>();
                         tc.Tooltip = element.option.tooltip;
@@ -159,9 +158,10 @@ public class SettingsMenu : MonoBehaviour
 
     public void Apply()
     {
-        if (options.ContainsKey(currentCategory))
+        Dictionary<string, BaseSettingsElement[]> option;
+        if (options.TryGetValue(currentCategory, out option))
         {
-            changesTracker.AddRange(options[currentCategory].Values.SelectMany(x => x).Where(x => x != null && x.valueChanged));
+            changesTracker.AddRange(option.Values.SelectMany(x => x).Where(x => x != null && x.valueChanged));
         }
 
         for (int i = 0; i < changesTracker.Count; i++)
@@ -224,9 +224,10 @@ public class SettingsMenu : MonoBehaviour
                 {
                     case DialogBoxResult.Yes:
                         // CANCEL
-                        if (options.ContainsKey(currentCategory))
+                        Dictionary<string, BaseSettingsElement[]> option;
+                        if (options.TryGetValue(currentCategory, out option))
                         {
-                            changesTracker.AddRange(options[currentCategory].Values.SelectMany(x => x).Where(x => x != null && x.valueChanged));
+                            changesTracker.AddRange(option.Values.SelectMany(x => x).Where(x => x != null && x.valueChanged));
                         }
 
                         Settings.LoadSettings();

--- a/Assets/Scripts/UI/Overlay/OverlayMap.cs
+++ b/Assets/Scripts/UI/Overlay/OverlayMap.cs
@@ -468,14 +468,14 @@ public class OverlayMap : MonoBehaviour
         {
             UnityDebugger.Debugger.LogError("OverlayMap", "No color map texture setted!");
         }
-        
-        if (!overlayColorMapLookup.ContainsKey(currentOverlay))
+
+        Dictionary<int, Color> colorMapLookup;
+        if (overlayColorMapLookup.TryGetValue(currentOverlay, out colorMapLookup) == false)
         {
-            overlayColorMapLookup.Add(currentOverlay, new Dictionary<int, Color>());
+            colorMapLookup = new Dictionary<int, Color>();
+            overlayColorMapLookup.Add(currentOverlay, colorMapLookup);
         }
-
-        Dictionary<int, Color> colorMapLookup = overlayColorMapLookup[currentOverlay];
-
+        
         // Size in pixels of overlay texture and create texture.
         int textureWidth = sizeX;
         int textureHeight = sizeY;
@@ -490,12 +490,13 @@ public class OverlayMap : MonoBehaviour
 
                 int sampleX = ((int)v % 256) * colorMapWidth;
 
-                if (!colorMapLookup.ContainsKey(sampleX))
+                Color pixel;
+                if (colorMapLookup.TryGetValue(sampleX, out pixel) == false)
                 {
-                    colorMapLookup.Add(sampleX, colorMapTexture.GetPixel(sampleX, 0));
+                    pixel = colorMapTexture.GetPixel(sampleX, 0);
+                    colorMapLookup.Add(sampleX, pixel);
                 }
-
-                Color pixel = colorMapLookup[sampleX];
+                
                 int tilePixelIndex = (y * sizeX) + x;
                 pixels[tilePixelIndex] = pixel;
             }


### PR DESCRIPTION
### What this PR does

Replaces a lot of `ContainsKey` calls with `TryGetValue` as that is basically always what you want to do when you call `ContainsKey`. And if you really just want the `ContainsKey` functionality you just use `TryGetValue` and discard the actual value.

This will 9/10 times make the code cleaner and 10/10 times make the code more performant.

Now we just need C#7 to make all the `TryGetValue` calls so much nicer to look at.