### PR TITLE
Suspends jobs if they can't be reached.

### DIFF
--- a/Assets/Scripts/Models/Job/Job.cs
+++ b/Assets/Scripts/Models/Job/Job.cs
@@ -367,14 +367,10 @@ public class Job : ISelectable
         }
     }
 
-    public void Suspend()
-    {
-        IsActive = false;
-    }
-
     public void SuspendCantReach()
     {
         World.Current.RoomManager.Removed += (room) => ClearCharCantReach();
+        tile.TileChanged += (tile) => ClearCharCantReach();
         Suspend();
     }
 
@@ -632,6 +628,12 @@ public class Job : ISelectable
     /// </summary>
     public void ClearCharCantReach()
     {
+        World.Current.RoomManager.Removed -= (room) => ClearCharCantReach();
+        if (tile != null)
+        {
+            tile.TileChanged -= (tile) => ClearCharCantReach();
+        }
+
         charsCantReach.Clear();
         IsActive = true;
     }
@@ -639,5 +641,10 @@ public class Job : ISelectable
     public IEnumerable<string> GetAdditionalInfo()
     {
         yield break;
+    }
+
+    private void Suspend()
+    {
+        IsActive = false;
     }
 }


### PR DESCRIPTION
This will check to see if a job can be reached before pathing to it, making mining large patches much less annoying.

Still won't work perfectly if in the middle of an unreachable room, but that will come with a future upgrade.