### PR TITLE
Fix pending build jobs

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
@@ -299,7 +299,7 @@ public class BuildModeController : IMouseHandler
                 }
                 else
                 {
-                    UnityDebugger.Debugger.LogError("BuildModeController", "There is no furniture job prototype for '" + utilityType + "'");
+                    UnityDebugger.Debugger.LogError("BuildModeController", "There is no utility job prototype for '" + utilityType + "'");
                     job = new Job(tile, utilityType, World.Current.UtilityManager.ConstructJobCompleted, 0.1f, null, Job.JobPriority.High, "construct")
                     {
                         Description = "job_build_" + utilityType + "_desc"

--- a/Assets/Scripts/Models/Buildable/BuildableJobs.cs
+++ b/Assets/Scripts/Models/Buildable/BuildableJobs.cs
@@ -211,7 +211,8 @@ public class BuildableJobs
             foreach (Job job in jobsArray)
             {
                 pausedJobs.Add(job);
-                job.CancelJob();
+
+                // We formerly called Called job.CancelJob() here, but that is incorrect for pausing a job, we may have to do cleanup that is now no longer done
             }
         }
     }

--- a/Assets/Scripts/Models/Buildable/UtilityManager.cs
+++ b/Assets/Scripts/Models/Buildable/UtilityManager.cs
@@ -83,10 +83,6 @@ public class UtilityManager : IEnumerable<Utility>
     public void ConstructJobCompleted(Job job)
     {
         PlaceUtility(job.Type, job.tile);
-
-        // FIXME: I don't like having to manually and explicitly set
-        // flags that preven conflicts. It's too easy to forget to set/clear them!
-        job.tile.PendingBuildJobs.Remove(job);
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/Job/Job.cs
+++ b/Assets/Scripts/Models/Job/Job.cs
@@ -356,6 +356,7 @@ public class Job : ISelectable
                 // Let everyone know that the job is officially concluded
                 if (OnJobStopped != null)
                 {
+                    Debug.LogWarning("Job stopped from finishing work");
                     OnJobStopped(this);
                 }
             }
@@ -410,6 +411,8 @@ public class Job : ISelectable
     {
         if (OnJobStopped != null)
         {
+
+            Debug.LogWarning("Job stopped from being cancelled");
             OnJobStopped(this);
         }
 

--- a/Assets/Scripts/Models/Job/Job.cs
+++ b/Assets/Scripts/Models/Job/Job.cs
@@ -356,7 +356,6 @@ public class Job : ISelectable
                 // Let everyone know that the job is officially concluded
                 if (OnJobStopped != null)
                 {
-                    Debug.LogWarning("Job stopped from finishing work");
                     OnJobStopped(this);
                 }
             }
@@ -411,8 +410,6 @@ public class Job : ISelectable
     {
         if (OnJobStopped != null)
         {
-
-            Debug.LogWarning("Job stopped from being cancelled");
             OnJobStopped(this);
         }
 

--- a/Assets/Scripts/State/JobState.cs
+++ b/Assets/Scripts/State/JobState.cs
@@ -101,7 +101,7 @@ namespace ProjectPorcupine.Entities.States
             Job.IsBeingWorked = false;
 
             // Tell anyone else who cares that it was cancelled
-            Job.CancelJob();
+            // We formerly called Called job.CancelJob() here, but that is incorrect for pausing a job, we may have to do cleanup that is now no longer done
 
             if (Job.IsNeed)
             {

--- a/Assets/Scripts/State/JobState.cs
+++ b/Assets/Scripts/State/JobState.cs
@@ -102,7 +102,6 @@ namespace ProjectPorcupine.Entities.States
 
             // Tell anyone else who cares that it was cancelled
             // We formerly called Called job.CancelJob() here, but that is incorrect for pausing a job, we may have to do cleanup that is now no longer done
-
             if (Job.IsNeed)
             {
                 return;


### PR DESCRIPTION
Cleans up a bit on where PendingBuildJobs is added to and removed from, also removed incorrect calls to CancelJob (was being called when the job was being paused), which should now allow jobs that have had some inventory delivered to them to be cancellable.